### PR TITLE
feat: use location UUID instead of profile ID for patient service API calls

### DIFF
--- a/src/context/ProfileContext.tsx
+++ b/src/context/ProfileContext.tsx
@@ -6,14 +6,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { showToast } from '../services/toast';
-import type { Profile } from '../types/profile.types';
-import type {
-  HealthWorkerProfile,
-  ProviderDetailResponse,
-  UserDetailResponse,
-} from '../types/provider.types';
-import { storage } from '../utils/storage';
 import {
   calculateAge,
   createHealthWorkerProfile,
@@ -27,10 +19,19 @@ import {
   type PersonDetailsType,
 } from '../modules/profile/profile.helpers';
 import profileService from '../modules/profile/profile.service';
+import { showToast } from '../services/toast';
+import type { Profile } from '../types/profile.types';
+import type {
+  HealthWorkerProfile,
+  ProviderDetailResponse,
+  UserDetailResponse,
+} from '../types/provider.types';
+import { storage } from '../utils/storage';
 
 export interface LocationOption {
   value: string;
   label: string;
+  uuid: string;
 }
 
 type ProfileUpdateData = {
@@ -49,6 +50,7 @@ interface ProfileContextType {
   hwProfile: HealthWorkerProfile | null;
   age: number | null;
   locations: LocationOption[];
+  locationUuid: string | null;
   uploadPhoto: (file: File) => Promise<void>;
   calculateAge: (dob: string) => number;
   updateAgeForDate: (dob: string) => void;
@@ -72,6 +74,9 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({
   const [hwProfile, setHwProfile] = useState<HealthWorkerProfile | null>(null);
   const [age, setAge] = useState<number | null>(null);
   const [locations, setLocations] = useState<LocationOption[]>([]);
+  const [locationUuid, setLocationUuid] = useState<string | null>(() =>
+    storage.getLocationUuid()
+  );
   const providerRef = useRef<ProviderDetailResponse | null>(null);
   const avatarTsRef = useRef(Date.now());
 
@@ -100,6 +105,7 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({
           res?.results?.map(loc => ({
             value: loc.display?.trim(),
             label: loc.display?.trim(),
+            uuid: loc.uuid,
           })) || []
         );
       } catch (e) {
@@ -107,6 +113,16 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     })();
   }, []);
+
+  useEffect(() => {
+    if (profile?.setupLocation && locations.length > 0) {
+      const match = locations.find(loc => loc.value === profile.setupLocation);
+      if (match) {
+        storage.setLocationUuid(match.uuid);
+        setLocationUuid(match.uuid);
+      }
+    }
+  }, [profile?.setupLocation, locations]);
 
   const loadProfile = useCallback(async () => {
     try {
@@ -297,6 +313,7 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({
     hwProfile,
     age,
     locations,
+    locationUuid,
     uploadPhoto,
     calculateAge,
     updateAgeForDate,

--- a/src/hooks/useOpenVisits.ts
+++ b/src/hooks/useOpenVisits.ts
@@ -3,21 +3,21 @@ import { useProfileContext } from '../context/ProfileContext';
 import { patientService, type OpenVisit } from '../services/patient.service';
 
 export const useOpenVisits = () => {
-  const { profile } = useProfileContext();
+  const { locationUuid } = useProfileContext();
   const [data, setData] = useState<OpenVisit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!profile?.id) return;
+    if (!locationUuid) return;
     setLoading(true);
     setError(null);
     patientService
-      .getOpenVisits(profile.id)
+      .getOpenVisits(locationUuid)
       .then(setData)
       .catch(() => setError('Failed to fetch open visits'))
       .finally(() => setLoading(false));
-  }, [profile?.id]);
+  }, [locationUuid]);
 
   return { data, loading, error, totalCount: data.length };
 };

--- a/src/hooks/usePrescriptionsPending.ts
+++ b/src/hooks/usePrescriptionsPending.ts
@@ -6,21 +6,21 @@ import {
 } from '../services/patient.service';
 
 export const usePrescriptionsPending = () => {
-  const { profile } = useProfileContext();
+  const { locationUuid } = useProfileContext();
   const [data, setData] = useState<PrescriptionPendingVisit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!profile?.id) return;
+    if (!locationUuid) return;
     setLoading(true);
     setError(null);
     patientService
-      .getPrescriptionsPending(profile.id)
+      .getPrescriptionsPending(locationUuid)
       .then(setData)
       .catch(() => setError('Failed to fetch pending prescriptions'))
       .finally(() => setLoading(false));
-  }, [profile?.id]);
+  }, [locationUuid]);
 
   return { data, loading, error, totalCount: data.length };
 };

--- a/src/hooks/usePrescriptionsReceived.ts
+++ b/src/hooks/usePrescriptionsReceived.ts
@@ -6,21 +6,21 @@ import {
 } from '../services/patient.service';
 
 export const usePrescriptionsReceived = () => {
-  const { profile } = useProfileContext();
+  const { locationUuid } = useProfileContext();
   const [data, setData] = useState<PrescriptionReceivedVisit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!profile?.id) return;
+    if (!locationUuid) return;
     setLoading(true);
     setError(null);
     patientService
-      .getPrescriptionsReceived(profile.id)
+      .getPrescriptionsReceived(locationUuid)
       .then(setData)
       .catch(() => setError('Failed to fetch prescriptions'))
       .finally(() => setLoading(false));
-  }, [profile?.id]);
+  }, [locationUuid]);
 
   return { data, loading, error, totalCount: data.length };
 };

--- a/src/test/hooks/useOpenVisits.test.ts
+++ b/src/test/hooks/useOpenVisits.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetOpenVisits = vi.fn();
-const mockProfile = { id: 'hw-uuid-123' };
+const MOCK_LOCATION_UUID = 'loc-uuid-123';
 const mockUseProfileContext = vi.fn();
 
 vi.mock('../../context/ProfileContext', () => ({
@@ -41,7 +41,7 @@ const mockVisits = [
 describe('useOpenVisits', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseProfileContext.mockReturnValue({ profile: mockProfile });
+    mockUseProfileContext.mockReturnValue({ locationUuid: MOCK_LOCATION_UUID });
   });
 
   it('initialises with empty data, loading false, no error', () => {
@@ -75,12 +75,12 @@ describe('useOpenVisits', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('calls getOpenVisits with the profile id', async () => {
+  it('calls getOpenVisits with the location uuid', async () => {
     mockGetOpenVisits.mockResolvedValue([]);
     renderHook(() => useOpenVisits());
 
     await waitFor(() => {
-      expect(mockGetOpenVisits).toHaveBeenCalledWith('hw-uuid-123');
+      expect(mockGetOpenVisits).toHaveBeenCalledWith(MOCK_LOCATION_UUID);
     });
   });
 
@@ -96,17 +96,46 @@ describe('useOpenVisits', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('does not fetch when profile id is not available', () => {
-    mockUseProfileContext.mockReturnValue({ profile: null });
+  it('does not fetch when locationUuid is null', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: null });
     renderHook(() => useOpenVisits());
 
     expect(mockGetOpenVisits).not.toHaveBeenCalled();
   });
 
-  it('does not fetch when profile has no id', () => {
-    mockUseProfileContext.mockReturnValue({ profile: {} });
+  it('does not fetch when locationUuid is undefined', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: undefined });
     renderHook(() => useOpenVisits());
 
     expect(mockGetOpenVisits).not.toHaveBeenCalled();
+  });
+
+  it('totalCount reflects length of data array', async () => {
+    mockGetOpenVisits.mockResolvedValue(mockVisits);
+    const { result } = renderHook(() => useOpenVisits());
+
+    await waitFor(() => {
+      expect(result.current.totalCount).toBe(mockVisits.length);
+    });
+  });
+
+  it('re-fetches when locationUuid changes', async () => {
+    mockGetOpenVisits.mockResolvedValue(mockVisits);
+    let locationUuid = MOCK_LOCATION_UUID;
+    mockUseProfileContext.mockImplementation(() => ({ locationUuid }));
+
+    const { rerender } = renderHook(() => useOpenVisits());
+    await waitFor(() => {
+      expect(mockGetOpenVisits).toHaveBeenCalledTimes(1);
+    });
+
+    locationUuid = 'loc-uuid-new';
+    mockGetOpenVisits.mockResolvedValue([]);
+    rerender();
+
+    await waitFor(() => {
+      expect(mockGetOpenVisits).toHaveBeenCalledTimes(2);
+      expect(mockGetOpenVisits).toHaveBeenLastCalledWith('loc-uuid-new');
+    });
   });
 });

--- a/src/test/hooks/usePrescriptionsPending.test.ts
+++ b/src/test/hooks/usePrescriptionsPending.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetPrescriptionsPending = vi.fn();
-const mockProfile = { id: 'hw-uuid-789' };
+const MOCK_LOCATION_UUID = 'loc-uuid-789';
 const mockUseProfileContext = vi.fn();
 
 vi.mock('../../context/ProfileContext', () => ({
@@ -41,7 +41,7 @@ const mockPendingVisits = [
 describe('usePrescriptionsPending', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseProfileContext.mockReturnValue({ profile: mockProfile });
+    mockUseProfileContext.mockReturnValue({ locationUuid: MOCK_LOCATION_UUID });
   });
 
   it('initialises with empty data, loading false, no error', () => {
@@ -75,12 +75,12 @@ describe('usePrescriptionsPending', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('calls getPrescriptionsPending with the profile id', async () => {
+  it('calls getPrescriptionsPending with the location uuid', async () => {
     mockGetPrescriptionsPending.mockResolvedValue([]);
     renderHook(() => usePrescriptionsPending());
 
     await waitFor(() => {
-      expect(mockGetPrescriptionsPending).toHaveBeenCalledWith('hw-uuid-789');
+      expect(mockGetPrescriptionsPending).toHaveBeenCalledWith(MOCK_LOCATION_UUID);
     });
   });
 
@@ -96,15 +96,15 @@ describe('usePrescriptionsPending', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('does not fetch when profile is null', () => {
-    mockUseProfileContext.mockReturnValue({ profile: null });
+  it('does not fetch when locationUuid is null', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: null });
     renderHook(() => usePrescriptionsPending());
 
     expect(mockGetPrescriptionsPending).not.toHaveBeenCalled();
   });
 
-  it('does not fetch when profile has no id', () => {
-    mockUseProfileContext.mockReturnValue({ profile: {} });
+  it('does not fetch when locationUuid is undefined', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: undefined });
     renderHook(() => usePrescriptionsPending());
 
     expect(mockGetPrescriptionsPending).not.toHaveBeenCalled();
@@ -116,6 +116,26 @@ describe('usePrescriptionsPending', () => {
 
     await waitFor(() => {
       expect(result.current.totalCount).toBe(mockPendingVisits.length);
+    });
+  });
+
+  it('re-fetches when locationUuid changes', async () => {
+    mockGetPrescriptionsPending.mockResolvedValue(mockPendingVisits);
+    let locationUuid = MOCK_LOCATION_UUID;
+    mockUseProfileContext.mockImplementation(() => ({ locationUuid }));
+
+    const { rerender } = renderHook(() => usePrescriptionsPending());
+    await waitFor(() => {
+      expect(mockGetPrescriptionsPending).toHaveBeenCalledTimes(1);
+    });
+
+    locationUuid = 'loc-uuid-new';
+    mockGetPrescriptionsPending.mockResolvedValue([]);
+    rerender();
+
+    await waitFor(() => {
+      expect(mockGetPrescriptionsPending).toHaveBeenCalledTimes(2);
+      expect(mockGetPrescriptionsPending).toHaveBeenLastCalledWith('loc-uuid-new');
     });
   });
 });

--- a/src/test/hooks/usePrescriptionsReceived.test.ts
+++ b/src/test/hooks/usePrescriptionsReceived.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetPrescriptionsReceived = vi.fn();
-const mockProfile = { id: 'hw-uuid-456' };
+const MOCK_LOCATION_UUID = 'loc-uuid-456';
 const mockUseProfileContext = vi.fn();
 
 vi.mock('../../context/ProfileContext', () => ({
@@ -41,7 +41,7 @@ const mockPrescriptions = [
 describe('usePrescriptionsReceived', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseProfileContext.mockReturnValue({ profile: mockProfile });
+    mockUseProfileContext.mockReturnValue({ locationUuid: MOCK_LOCATION_UUID });
   });
 
   it('initialises with empty data, loading false, no error', () => {
@@ -75,12 +75,12 @@ describe('usePrescriptionsReceived', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('calls getPrescriptionsReceived with the profile id', async () => {
+  it('calls getPrescriptionsReceived with the location uuid', async () => {
     mockGetPrescriptionsReceived.mockResolvedValue([]);
     renderHook(() => usePrescriptionsReceived());
 
     await waitFor(() => {
-      expect(mockGetPrescriptionsReceived).toHaveBeenCalledWith('hw-uuid-456');
+      expect(mockGetPrescriptionsReceived).toHaveBeenCalledWith(MOCK_LOCATION_UUID);
     });
   });
 
@@ -96,15 +96,15 @@ describe('usePrescriptionsReceived', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('does not fetch when profile is null', () => {
-    mockUseProfileContext.mockReturnValue({ profile: null });
+  it('does not fetch when locationUuid is null', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: null });
     renderHook(() => usePrescriptionsReceived());
 
     expect(mockGetPrescriptionsReceived).not.toHaveBeenCalled();
   });
 
-  it('does not fetch when profile has no id', () => {
-    mockUseProfileContext.mockReturnValue({ profile: {} });
+  it('does not fetch when locationUuid is undefined', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: undefined });
     renderHook(() => usePrescriptionsReceived());
 
     expect(mockGetPrescriptionsReceived).not.toHaveBeenCalled();
@@ -116,6 +116,26 @@ describe('usePrescriptionsReceived', () => {
 
     await waitFor(() => {
       expect(result.current.totalCount).toBe(mockPrescriptions.length);
+    });
+  });
+
+  it('re-fetches when locationUuid changes', async () => {
+    mockGetPrescriptionsReceived.mockResolvedValue(mockPrescriptions);
+    let locationUuid = MOCK_LOCATION_UUID;
+    mockUseProfileContext.mockImplementation(() => ({ locationUuid }));
+
+    const { rerender } = renderHook(() => usePrescriptionsReceived());
+    await waitFor(() => {
+      expect(mockGetPrescriptionsReceived).toHaveBeenCalledTimes(1);
+    });
+
+    locationUuid = 'loc-uuid-new';
+    mockGetPrescriptionsReceived.mockResolvedValue([]);
+    rerender();
+
+    await waitFor(() => {
+      expect(mockGetPrescriptionsReceived).toHaveBeenCalledTimes(2);
+      expect(mockGetPrescriptionsReceived).toHaveBeenLastCalledWith('loc-uuid-new');
     });
   });
 });

--- a/src/test/modules/profile/profile-form-fields.component.test.tsx
+++ b/src/test/modules/profile/profile-form-fields.component.test.tsx
@@ -223,7 +223,7 @@ describe('ProfileFormFields', () => {
         trigger={mockTrigger}
         onPhotoModalOpen={mockOnPhotoModalOpen}
         onCountryChange={mockOnCountryChange}
-        locationOptions={[{ value: 'telemedicine-clinic1 ', label: 'telemedicine-clinic1 ' }]}
+        locationOptions={[{ value: 'telemedicine-clinic1 ', label: 'telemedicine-clinic1 ', uuid: 'loc-uuid-1' }]}
       />
     );
 

--- a/src/test/modules/profile/profile.hooks.test.ts
+++ b/src/test/modules/profile/profile.hooks.test.ts
@@ -1,19 +1,19 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mocked,
-  type MockedFunction,
-} from 'vitest';
 import React from 'react';
-import { useProfileContext as useProfile, ProfileProvider } from '../../../context/ProfileContext';
-import mockProfileService from '../../../modules/profile/profile.service';
-import { storage as mockStorage } from '../../../utils/storage';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mocked,
+    type MockedFunction,
+} from 'vitest';
+import { ProfileProvider, useProfileContext as useProfile } from '../../../context/ProfileContext';
 import * as helpers from '../../../modules/profile/profile.helpers';
+import mockProfileService from '../../../modules/profile/profile.service';
 import * as toast from '../../../services/toast';
+import { storage as mockStorage } from '../../../utils/storage';
 
 // ---------- MOCK TOAST ----------
 vi.mock('../../../services/toast', () => ({
@@ -107,6 +107,8 @@ vi.mock('../../../utils/storage', () => ({
     getUser: vi.fn(),
     setLocationName: vi.fn(),
     getLocationName: vi.fn(),
+    getLocationUuid: vi.fn(() => null),
+    setLocationUuid: vi.fn(),
   },
 }));
 
@@ -1894,8 +1896,8 @@ describe('useProfile', () => {
 
     await waitFor(() => {
       expect(result.current.locations).toHaveLength(2);
-      expect(result.current.locations[0]).toEqual({ value: 'Main Clinic', label: 'Main Clinic' });
-      expect(result.current.locations[1]).toEqual({ value: 'Branch Clinic', label: 'Branch Clinic' });
+      expect(result.current.locations[0]).toEqual({ value: 'Main Clinic', label: 'Main Clinic', uuid: 'loc1' });
+      expect(result.current.locations[1]).toEqual({ value: 'Branch Clinic', label: 'Branch Clinic', uuid: 'loc2' });
     });
   });
 

--- a/src/test/modules/profile/profile.hooks.test.ts
+++ b/src/test/modules/profile/profile.hooks.test.ts
@@ -2061,4 +2061,114 @@ describe('useProfile', () => {
     });
   });
 
+  it('resolves and stores locationUuid when setupLocation matches a loaded location', async () => {
+    const mockGetUser = mockStorage.getUser as MockedFunction<
+      typeof mockStorage.getUser
+    >;
+    mockGetUser.mockReturnValue(
+      JSON.stringify({ uuid: 'user123', person: { uuid: 'person123' } })
+    );
+
+    // Return real locations so locations.length > 0
+    mockedProfileService.getLocations.mockResolvedValueOnce({
+      results: [
+        { uuid: 'loc-uuid-match', display: 'Health Clinic' },
+        { uuid: 'loc-uuid-other', display: 'Branch Clinic' },
+      ],
+    } as any);
+
+    mockedProfileService.getUserByUuid.mockResolvedValue({
+      uuid: 'user123',
+      person: { uuid: 'person123' },
+      roles: [],
+      privileges: [],
+      retired: false,
+      userProperties: {},
+    } as any);
+
+    mockedProfileService.getProvider.mockResolvedValue({ results: [] } as any);
+
+    mockedProfileService.getPersonByUuid.mockResolvedValue({
+      uuid: 'person123',
+      display: 'John Doe',
+      attributes: [],
+    } as any);
+
+    mockedProfileService.getProfileImage.mockRejectedValue({ status: 404 });
+
+    // Profile whose setupLocation matches the first location
+    mockedHelpers.createProfile.mockReturnValueOnce({
+      id: 'person123',
+      firstName: 'John',
+      lastName: 'Doe',
+      gender: 'male' as const,
+      setupLocation: 'Health Clinic',
+      address: { street: '', city: '', state: '', country: '', zipCode: '' },
+      preferences: { language: 'en', timezone: 'UTC', notifications: { email: false, sms: false, push: false } },
+    } as any);
+
+    const { result } = renderHook(() => useProfile(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockStorage.setLocationUuid).toHaveBeenCalledWith('loc-uuid-match');
+    });
+
+    expect(result.current.locationUuid).toBe('loc-uuid-match');
+  });
+
+  it('does not call setLocationUuid when setupLocation does not match any location', async () => {
+    const mockGetUser = mockStorage.getUser as MockedFunction<
+      typeof mockStorage.getUser
+    >;
+    mockGetUser.mockReturnValue(
+      JSON.stringify({ uuid: 'user123', person: { uuid: 'person123' } })
+    );
+
+    // Return locations that do NOT include the profile's setupLocation
+    mockedProfileService.getLocations.mockResolvedValueOnce({
+      results: [
+        { uuid: 'loc-uuid-other', display: 'Other Clinic' },
+      ],
+    } as any);
+
+    mockedProfileService.getUserByUuid.mockResolvedValue({
+      uuid: 'user123',
+      person: { uuid: 'person123' },
+      roles: [],
+      privileges: [],
+      retired: false,
+      userProperties: {},
+    } as any);
+
+    mockedProfileService.getProvider.mockResolvedValue({ results: [] } as any);
+
+    mockedProfileService.getPersonByUuid.mockResolvedValue({
+      uuid: 'person123',
+      display: 'John Doe',
+      attributes: [],
+    } as any);
+
+    mockedProfileService.getProfileImage.mockRejectedValue({ status: 404 });
+
+    mockedHelpers.createProfile.mockReturnValueOnce({
+      id: 'person123',
+      firstName: 'John',
+      lastName: 'Doe',
+      gender: 'male' as const,
+      setupLocation: 'Non-Existent Clinic',
+      address: { street: '', city: '', state: '', country: '', zipCode: '' },
+      preferences: { language: 'en', timezone: 'UTC', notifications: { email: false, sms: false, push: false } },
+    } as any);
+
+    const { result } = renderHook(() => useProfile(), { wrapper });
+
+    // Wait until both profile and locations are loaded so the useEffect runs
+    await waitFor(() => {
+      expect(result.current.profile).not.toBeNull();
+      expect(result.current.locations.length).toBeGreaterThan(0);
+    });
+
+    expect(mockStorage.setLocationUuid).not.toHaveBeenCalled();
+  });
+
 });

--- a/src/test/routes/app.routes.test.tsx
+++ b/src/test/routes/app.routes.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../../utils/storage', () => ({
     setAuthToken: vi.fn(),
     clearAuthToken: vi.fn(),
     getUser: vi.fn(() => null),
+    getLocationUuid: vi.fn(() => null),
+    setLocationUuid: vi.fn(),
   },
 }));
 


### PR DESCRIPTION
# Pull Request

## Description

- Update patientService hooks (useOpenVisits, usePrescriptionsPending,
  usePrescriptionsReceived) to pass locationUuid instead of profile.id
- Add uuid field to LocationOption interface in ProfileContext
- Expose locationUuid from ProfileContext, derived by matching
  profile.setupLocation against fetched locations list and persisted
  to localStorage 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] All pre-commit checks pass

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No console errors or warnings
- [ ] Responsive design tested (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer**: @Zeeshan-IH
**Assignee**: @Zeeshan-IH
