### PR TITLE
fix(physical-exam): camera tile label, summary text, image sizing, va…

### DIFF
--- a/src/hooks/usePriorityVisits.ts
+++ b/src/hooks/usePriorityVisits.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useProfileContext } from '../context/ProfileContext';
+import { patientService, type OpenVisit } from '../services/patient.service';
+
+export const usePriorityVisits = () => {
+  const { locationUuid } = useProfileContext();
+  const [data, setData] = useState<OpenVisit[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!locationUuid) return;
+    setLoading(true);
+    setError(null);
+    patientService
+      .getPriorityVisits(locationUuid)
+      .then(({ visits, totalCount: count }) => {
+        setData(visits);
+        setTotalCount(count);
+      })
+      .catch(() => setError('Failed to fetch priority visits'))
+      .finally(() => setLoading(false));
+  }, [locationUuid]);
+
+  return { data, loading, error, totalCount };
+};

--- a/src/modules/ayu-library/utils/constants.ts
+++ b/src/modules/ayu-library/utils/constants.ts
@@ -53,6 +53,13 @@ export const EXT_URL_PE_OPTION_KIND =
   'urn:intelehealth:physical-exam/option-kind';
 export const PE_OPTION_KIND_CAMERA = 'camera';
 
+/* physExam.json sometimes carries a sentinel answerOption whose `language`
+ * extension equals this marker. It is NOT a user-facing choice — it is a
+ * proxy that pairs with an attachment child for image capture. The
+ * transform drops these so the camera tile (built from the attachment)
+ * is the only rendering surface for that semantic. */
+export const PE_OPTION_LANG_MARKER_PICTURE_TAKEN = '[picture taken]';
+
 /*
  * Threshold that distinguishes a Frequency (occurrences) from a Range
  * component when both share the same FHIR shape (integer + minValue/maxValue).

--- a/src/modules/ayu-library/utils/fhir-to-ayu.util.ts
+++ b/src/modules/ayu-library/utils/fhir-to-ayu.util.ts
@@ -20,6 +20,7 @@ import {
   EXT_URL_JOB_AID_TYPE,
   EXT_URL_LANGUGAE_TEXT,
   EXT_URL_PE_CATEGORY_LABEL,
+  PE_OPTION_LANG_MARKER_PICTURE_TAKEN,
   EXT_URL_PE_OPTION_KIND,
   EXT_URL_PE_QUESTION_KEY,
   EXT_URL_PE_SECTION_KEY,
@@ -324,11 +325,11 @@ function findWrappedInnerChoice(q: FhirItem): FhirItem | null {
 function buildPhysExamCameraOption(child: FhirItem): AyuAnswerOption | null {
   if (child.type !== 'attachment') return null;
   const cameraCode = child.enableWhen?.[0]?.answerCoding?.code ?? child.linkId;
-  const langExt = child.extension?.find(e => e.url === EXT_URL_LANGUGAE_TEXT);
-  const cameraText =
-    langExt?.valueString && langExt.valueString !== '%'
-      ? langExt.valueString
-      : (child.text ?? 'Take a picture');
+  /* The stored `display` is what the stepper's answered-card view reads back
+   * for a committed camera answer. It must read "Picture Taken" — the tile
+   * itself renders a hardcoded "Take a Picture" label and ignores this
+   * field. The raw FHIR `language` extension carries marker strings like
+   * "[picture taken]" that must never reach the UI. */
   const isExclusive =
     child.extension?.find(e => e.url === EXT_URL_IS_EXCLUSIVE_OPTION)
       ?.valueString === 'true';
@@ -339,7 +340,7 @@ function buildPhysExamCameraOption(child: FhirItem): AyuAnswerOption | null {
     extension.push({ url: EXT_URL_IS_EXCLUSIVE_OPTION, valueString: 'true' });
   }
   return {
-    valueCoding: { code: cameraCode, display: cameraText },
+    valueCoding: { code: cameraCode, display: 'Picture Taken' },
     extension,
   };
 }
@@ -366,13 +367,27 @@ function buildPhysExamQuestion(
     e => e.url === EXT_URL_JOB_AID_TYPE || e.url === EXT_URL_JOB_AID_FILE
   );
 
-  const answerOption: AyuAnswerOption[] = (q.answerOption ?? []).map(opt => ({
-    valueString: opt.valueString,
-    valueInteger: opt.valueInteger,
-    valueDate: opt.valueDate,
-    valueCoding: opt.valueCoding,
-    extension: opt.extension,
-  }));
+  /* Drop "[picture taken]" marker answerOptions. They are not user-facing
+   * choices — they are a proxy for the attachment child below, which we
+   * surface separately as the camera tile. Without this, the option renders
+   * as a duplicate "Take a picture" tile next to the real camera tile.
+   *
+   * Filter is keyed on the `language` extension marker (not on attachment
+   * trigger codes) because Yes/No-style questions enable an attachment via
+   * the Yes/No codes themselves — those are real choices, not markers, and
+   * must be preserved. */
+  const answerOption: AyuAnswerOption[] = (q.answerOption ?? [])
+    .filter(opt => {
+      const langExt = opt.extension?.find(e => e.url === EXT_URL_LANGUGAE_TEXT);
+      return langExt?.valueString !== PE_OPTION_LANG_MARKER_PICTURE_TAKEN;
+    })
+    .map(opt => ({
+      valueString: opt.valueString,
+      valueInteger: opt.valueInteger,
+      valueDate: opt.valueDate,
+      valueCoding: opt.valueCoding,
+      extension: opt.extension,
+    }));
 
   for (const child of q.item ?? []) {
     const cameraOpt = buildPhysExamCameraOption(child);

--- a/src/modules/ayu/components/common/ayu-physical-exam-options.component.tsx
+++ b/src/modules/ayu/components/common/ayu-physical-exam-options.component.tsx
@@ -14,7 +14,11 @@ import { getRowLabel } from '../../../ayu-library/utils/question.utils';
 import { usePhysicalExamCamera } from '../start-visit/physical-examination/physical-exam-camera-context';
 import { PhysicalExamImageCapture } from '../start-visit/physical-examination/physical-exam-image-capture.component';
 import { getOptionIcon } from '../start-visit/physical-examination/physical-examination.utils';
-import { BUTTON_UPLOAD } from '../../utils/ayu.constants';
+import {
+  BUTTON_UPLOAD,
+  PE_CAMERA_TILE_LABEL,
+  VALIDATION_UPLOAD_IMAGE,
+} from '../../utils/ayu.constants';
 import AyuButton from './ayu-button.component';
 import { AyuSelectableOption } from './ayu-selectable-option.component';
 
@@ -41,6 +45,7 @@ export const AyuPhysicalExamOptions = ({
   const camera = usePhysicalExamCamera();
   const [cameraLocallySelected, setCameraLocallySelected] = useState(false);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
+  const [showUploadError, setShowUploadError] = useState(false);
 
   if (!question) return null;
 
@@ -96,15 +101,19 @@ export const AyuPhysicalExamOptions = ({
       // Deselecting — drop any in-progress images and clear local state
       camera?.clearCameraImages(question.linkId);
       setCameraLocallySelected(false);
+      setShowUploadError(false);
       return;
     }
     setCameraLocallySelected(true);
+    setShowUploadError(false);
   };
 
   const handleSubmit = () => {
-    /* Caller (the Submit button) is rendered only when submitVisible is true,
-     * which already implies cameraLocallySelected, cameraCode, and
-     * cameraImages.length > 0 — no defensive guard needed here. */
+    if (cameraImages.length === 0) {
+      setShowUploadError(true);
+      return;
+    }
+    setShowUploadError(false);
     const next = isMultiChoice
       ? [...selected.filter(id => id !== cameraCode), cameraCode!]
       : [cameraCode!];
@@ -115,8 +124,11 @@ export const AyuPhysicalExamOptions = ({
   /* Only the camera-commit case needs an in-component Submit, since a captured
    * image must be explicitly turned into an answer. Plain multi-choice defers
    * to the outer stepper container's Submit (which also validates required
-   * fields and advances via goNext) — otherwise two Submit buttons stack. */
-  const submitVisible = cameraLocallySelected && cameraImages.length > 0;
+   * fields and advances via goNext) — otherwise two Submit buttons stack.
+   * We show the button whenever the camera tile is locally selected (even with
+   * zero images) so the user has a clear action — clicking with no images
+   * surfaces an inline error rather than failing silently. */
+  const submitVisible = cameraLocallySelected;
 
   const submitJustHappened = !!submittedAt && Date.now() - submittedAt < 1500;
 
@@ -144,12 +156,16 @@ export const AyuPhysicalExamOptions = ({
         <div className="pb-2">
           <p className="text-xs text-gray-500 mb-1">References:</p>
           {jobAidType === 'video' ? (
-            <video src={jobAidUrl} controls className="rounded-md" />
+            <video
+              src={jobAidUrl}
+              controls
+              className="rounded-md max-w-xs w-full h-auto"
+            />
           ) : (
             <img
               src={jobAidUrl}
               alt={categoryLabel ?? ''}
-              className="rounded-md"
+              className="rounded-md max-w-xs w-full h-auto object-contain"
             />
           )}
         </div>
@@ -177,7 +193,10 @@ export const AyuPhysicalExamOptions = ({
         })}
         {cameraOption && cameraCode && (
           <AyuSelectableOption
-            label={cameraOption.valueCoding?.display ?? 'Take a picture'}
+            /* Always render the camera tile as "Take a Picture". The
+             * underlying option's display in the FHIR data can be a marker
+             * like "[picture taken]" — never expose that to the user. */
+            label={PE_CAMERA_TILE_LABEL}
             value={cameraCode}
             selected={cameraLocallySelected}
             leftIcon={<img src={iconCamera} alt="" className="w-4 h-4" />}
@@ -189,9 +208,17 @@ export const AyuPhysicalExamOptions = ({
         <div className="pb-3">
           <PhysicalExamImageCapture
             images={cameraImages}
-            onAdd={f => camera.addCameraImage(question.linkId, f)}
+            onAdd={f => {
+              camera.addCameraImage(question.linkId, f);
+              setShowUploadError(false);
+            }}
             onRemove={i => camera.removeCameraImage(question.linkId, i)}
           />
+          {showUploadError && cameraImages.length === 0 && (
+            <p className="text-xs text-red-500 mt-1 px-3">
+              {VALIDATION_UPLOAD_IMAGE}
+            </p>
+          )}
         </div>
       )}
       {submitVisible && (
@@ -202,8 +229,6 @@ export const AyuPhysicalExamOptions = ({
             size="sm"
             onClick={handleSubmit}
           >
-            {/* submitVisible already implies cameraLocallySelected && images
-             * present, so the upload-with-count label is the only state. */}
             {`${BUTTON_UPLOAD} (${cameraImages.length})`}
             {submitJustHappened && <img src={iconYes} alt="yes" />}
           </AyuButton>

--- a/src/modules/ayu/components/start-visit/physical-examination/physical-examination.component.tsx
+++ b/src/modules/ayu/components/start-visit/physical-examination/physical-examination.component.tsx
@@ -22,6 +22,7 @@ import type { PhysicalExamAnswers } from '../../../types/physical-exam.types';
 import {
   BUTTON_BACK,
   BUTTON_SAVE_NEXT,
+  PE_PICTURE_TAKEN_LABEL,
   PHYSICAL_EXAM_SUMMARY_TITLE,
   SUMMARY_CANCEL_TEXT,
   SUMMARY_CONFIRM_TEXT,
@@ -199,7 +200,7 @@ export const PhysicalExamination = (props: SectionProps) => {
           const display = opt.valueCoding?.display ?? '';
           if (isCameraOption(opt)) {
             const hasImages = cameraImagesFor(q.linkId).length > 0;
-            if (hasImages) summaryTexts.push('Picture taken');
+            if (hasImages) summaryTexts.push(PE_PICTURE_TAKEN_LABEL);
             // Cameras don't contribute to the plain details list (matches the
             // old PhysicalExamination behaviour).
           } else {

--- a/src/modules/ayu/utils/ayu.constants.ts
+++ b/src/modules/ayu/utils/ayu.constants.ts
@@ -40,6 +40,11 @@ export const VALIDATION_ALL_COMPULSORY =
   'All questions are compulsory, please answer';
 export const VALIDATION_ENTER_VALUE = 'Please enter a value';
 export const VALIDATION_SELECT_OPTION = 'Please select any one option';
+export const VALIDATION_UPLOAD_IMAGE = 'Please upload at least one image';
+
+// --- Physical Exam Camera ---
+export const PE_CAMERA_TILE_LABEL = 'Take a Picture';
+export const PE_PICTURE_TAKEN_LABEL = 'Picture Taken';
 
 // FHIR Stepper Constants
 export const DEFAULT_VISIT_REASON_TEXT = 'Visit reason';

--- a/src/modules/dashboard/open-visits.component.tsx
+++ b/src/modules/dashboard/open-visits.component.tsx
@@ -10,6 +10,7 @@ import iconPatientRecevied from '../../assets/icons/appointment/icons-patient-re
 import iconsvioletFieldAppointmentDetails from '../../assets/icons/appointment/violet-field-apm-appointment-details-icon.svg';
 import { ReusableGridTable } from '../../components/common/reusable-grid-table.component';
 import { useOpenVisits } from '../../hooks/useOpenVisits';
+import { usePriorityVisits } from '../../hooks/usePriorityVisits';
 import { useColumnSort } from '../../hooks/useColumnSort';
 import { useSortByName } from '../../hooks/useSortByName';
 import type { OpenVisit } from '../../services/patient.service';
@@ -45,19 +46,20 @@ export const OpenVisitsComponent = ({
     toggleSort: toggleNameSort,
     applySort: applyNameSort,
   } = useSortByName();
-  const { data, loading, error } = useOpenVisits();
+  const openVisits = useOpenVisits();
+  const priorityVisits = usePriorityVisits();
 
   const isPriorityTab = activeTab === OPEN_VISITS_TABS.PRIORITY;
+  /* Priority tab pulls from a dedicated endpoint (?type=priority-visits) so
+   * the backend owns the priority logic — no client-side isPriority filter. */
+  const { data, loading, error } = isPriorityTab ? priorityVisits : openVisits;
 
   const filtered = useMemo(() => {
-    const byTab = isPriorityTab
-      ? data.filter(p => p.isPriority === true)
-      : data;
-    const result = byTab.filter(p =>
+    const result = data.filter(p =>
       p.patientName.toLowerCase().includes(search.toLowerCase())
     );
     return applySort(applyNameSort(result));
-  }, [data, isPriorityTab, search, applySort, applyNameSort]);
+  }, [data, search, applySort, applyNameSort]);
 
   const columns: Column[] = [
     {

--- a/src/services/patient.service.ts
+++ b/src/services/patient.service.ts
@@ -147,6 +147,16 @@ export const patientService = {
     return { visits: res.data.visits, totalCount: res.data.totalCount };
   },
 
+  async getPriorityVisits(
+    hwId: string,
+    page = 0,
+    limit = 50
+  ): Promise<{ visits: OpenVisit[]; totalCount: number }> {
+    const url = `/pull/hw-visits/${hwId}?type=priority-visits&page=${page}&limit=${limit}`;
+    const res = await EmrMiddlewareApi.get<OpenVisitsResponse>(url);
+    return { visits: res.data.visits, totalCount: res.data.totalCount };
+  },
+
   async getPrescriptionsPending(
     hwId: string,
     page = 0,

--- a/src/test/hooks/usePriorityVisits.test.ts
+++ b/src/test/hooks/usePriorityVisits.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetPriorityVisits = vi.fn();
+const MOCK_LOCATION_UUID = 'loc-uuid-123';
+const mockUseProfileContext = vi.fn();
+
+vi.mock('../../context/ProfileContext', () => ({
+  useProfileContext: () => mockUseProfileContext(),
+}));
+
+vi.mock('../../services/patient.service', () => ({
+  patientService: {
+    getPriorityVisits: (...args: unknown[]) => mockGetPriorityVisits(...args),
+  },
+}));
+
+import { usePriorityVisits } from '../../hooks/usePriorityVisits';
+
+const mockVisits = [
+  {
+    visitUuid: 'pv-1',
+    patientName: 'Anita Desai',
+    gender: 'F',
+    age: 42,
+    visitCreatedDate: '2025-04-20',
+    clinicName: 'TM Clinic 2',
+    uploadTimestamp: '1 hr ago',
+    isPriority: true,
+  },
+];
+
+describe('usePriorityVisits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseProfileContext.mockReturnValue({ locationUuid: MOCK_LOCATION_UUID });
+  });
+
+  it('initialises with empty data, loading false, no error', () => {
+    mockGetPriorityVisits.mockResolvedValue({ visits: [], totalCount: 0 });
+    const { result } = renderHook(() => usePriorityVisits());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.totalCount).toBe(0);
+  });
+
+  it('fetches priority visits and populates data', async () => {
+    mockGetPriorityVisits.mockResolvedValue({
+      visits: mockVisits,
+      totalCount: mockVisits.length,
+    });
+    const { result } = renderHook(() => usePriorityVisits());
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockVisits);
+    });
+
+    expect(result.current.totalCount).toBe(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls getPriorityVisits with the location uuid', async () => {
+    mockGetPriorityVisits.mockResolvedValue({ visits: [], totalCount: 0 });
+    renderHook(() => usePriorityVisits());
+
+    await waitFor(() => {
+      expect(mockGetPriorityVisits).toHaveBeenCalledWith(MOCK_LOCATION_UUID);
+    });
+  });
+
+  it('sets error message when API call fails', async () => {
+    mockGetPriorityVisits.mockRejectedValue(new Error('Network error'));
+    const { result } = renderHook(() => usePriorityVisits());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Failed to fetch priority visits');
+    });
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not fetch when locationUuid is null', () => {
+    mockUseProfileContext.mockReturnValue({ locationUuid: null });
+    renderHook(() => usePriorityVisits());
+
+    expect(mockGetPriorityVisits).not.toHaveBeenCalled();
+  });
+
+  it('re-fetches when locationUuid changes', async () => {
+    mockGetPriorityVisits.mockResolvedValue({
+      visits: mockVisits,
+      totalCount: mockVisits.length,
+    });
+    let locationUuid = MOCK_LOCATION_UUID;
+    mockUseProfileContext.mockImplementation(() => ({ locationUuid }));
+
+    const { rerender } = renderHook(() => usePriorityVisits());
+    await waitFor(() => {
+      expect(mockGetPriorityVisits).toHaveBeenCalledTimes(1);
+    });
+
+    locationUuid = 'loc-uuid-new';
+    mockGetPriorityVisits.mockResolvedValue({ visits: [], totalCount: 0 });
+    rerender();
+
+    await waitFor(() => {
+      expect(mockGetPriorityVisits).toHaveBeenCalledTimes(2);
+      expect(mockGetPriorityVisits).toHaveBeenLastCalledWith('loc-uuid-new');
+    });
+  });
+});

--- a/src/test/modules/ayu-library/utils/fhir-to-ayu.util.test.ts
+++ b/src/test/modules/ayu-library/utils/fhir-to-ayu.util.test.ts
@@ -1659,7 +1659,10 @@ describe('transformFhirPhysExamToAyu', () => {
     const camera = root?.item?.[0]?.answerOption?.find(
       o => o.valueCoding?.code === 'CAMERA'
     );
-    expect(camera?.valueCoding?.display).toBe('Take a picture');
+    // The stored display is "Picture Taken" so the stepper's answered card
+    // reads back the post-capture label. The tile renders a hardcoded
+    // "Take a Picture" label and ignores this field.
+    expect(camera?.valueCoding?.display).toBe('Picture Taken');
     expect(camera?.extension).toEqual(
       expect.arrayContaining([
         { url: EXT_URL_PE_OPTION_KIND, valueString: PE_OPTION_KIND_CAMERA },
@@ -1719,6 +1722,114 @@ describe('transformFhirPhysExamToAyu', () => {
         { url: EXT_URL_IS_EXCLUSIVE_OPTION, valueString: 'true' },
       ])
     );
+  });
+
+  it('drops "[picture taken]" marker answerOptions so the camera tile is not duplicated', () => {
+    // Mirrors a question in physExam.json (e.g. linkId "1afo09f1e5ijjoum5sb3utlter")
+    // that carries a sentinel answerOption with display="Take a picture" and
+    // language extension "[picture taken]" alongside an attachment child.
+    // Without the filter, the FHIR option renders as a regular tile next to
+    // the real camera tile built from the attachment.
+    const root = transformFhirPhysExamToAyu({
+      resourceType: 'Questionnaire',
+      item: [
+        makeSection('Hands', ['Nails'], [
+          {
+            linkId: 'q-marker',
+            text: 'Nails',
+            type: 'choice',
+            answerOption: [
+              { valueCoding: { code: 'real-yes', display: 'Yes' } },
+              {
+                valueCoding: { code: 'marker', display: 'Take a picture' },
+                extension: [
+                  {
+                    url: EXT_URL_LANGUGAE_TEXT,
+                    valueString: '[picture taken]',
+                  },
+                ],
+              },
+            ],
+            item: [
+              {
+                linkId: 'q-marker_attach',
+                type: 'attachment',
+                enableWhen: [
+                  {
+                    question: 'q-marker',
+                    operator: '=',
+                    answerCoding: { code: 'marker' },
+                  },
+                ],
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    const codes = root?.item?.[0]?.answerOption?.map(
+      o => o.valueCoding?.code
+    );
+    // marker option is dropped; real Yes survives; camera option built from
+    // the attachment is appended at the end.
+    expect(codes).toEqual(['real-yes', 'marker']);
+    // The remaining "marker" code is the camera-marked option (PE_OPTION_KIND
+    // extension), NOT the original sentinel.
+    const marker = root?.item?.[0]?.answerOption?.find(
+      o => o.valueCoding?.code === 'marker'
+    );
+    expect(marker?.extension).toEqual(
+      expect.arrayContaining([
+        { url: EXT_URL_PE_OPTION_KIND, valueString: PE_OPTION_KIND_CAMERA },
+      ])
+    );
+  });
+
+  it('preserves Yes/No answerOptions when the attachment enables on those codes (no false dedup)', () => {
+    // Mirrors the 1st jaundice question: enableWhen entries on the
+    // attachment reference the real Yes/No answer codes. Those codes must
+    // NOT be filtered out — they are real user choices, not "[picture taken]"
+    // markers.
+    const root = transformFhirPhysExamToAyu({
+      resourceType: 'Questionnaire',
+      item: [
+        makeSection('Eyes', ['Jaundice'], [
+          {
+            linkId: 'q-jaundice',
+            text: 'Is there jaundice?',
+            type: 'choice',
+            answerOption: [
+              { valueCoding: { code: 'no', display: 'No' } },
+              { valueCoding: { code: 'yes', display: 'Yes' } },
+            ],
+            item: [
+              {
+                linkId: 'q-jaundice_attach',
+                type: 'attachment',
+                enableWhen: [
+                  {
+                    question: 'q-jaundice',
+                    operator: '=',
+                    answerCoding: { code: 'no' },
+                  },
+                  {
+                    question: 'q-jaundice',
+                    operator: '=',
+                    answerCoding: { code: 'yes' },
+                  },
+                ],
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    const codes = root?.item?.[0]?.answerOption?.map(
+      o => o.valueCoding?.code
+    );
+    // Both real choices survive; camera option (also code 'no' from
+    // enableWhen[0]) is appended after.
+    expect(codes).toEqual(['no', 'yes', 'no']);
   });
 
   it('passes job-aid extensions through to the question', () => {

--- a/src/test/modules/ayu/components/common/ayu-physical-exam-options.component.test.tsx
+++ b/src/test/modules/ayu/components/common/ayu-physical-exam-options.component.test.tsx
@@ -125,7 +125,7 @@ describe('AyuPhysicalExamOptions', () => {
       expect(screen.getByRole('button', { name: /^No$/ })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /^Yes$/ })).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       ).toBeInTheDocument();
     });
 
@@ -368,8 +368,10 @@ describe('AyuPhysicalExamOptions', () => {
       ).toBeInTheDocument();
     });
 
-    it('falls back to "Take a picture" when the camera option has no display label', () => {
-      // Covers the `cameraOption.valueCoding?.display ?? 'Take a picture'` fallback.
+    it('renders the camera tile with the hardcoded "Take a Picture" label regardless of the option display', () => {
+      // The component intentionally ignores the option's display value because
+      // physExam.json sometimes carries marker strings (e.g. "[picture taken]")
+      // in that slot. The tile must always read "Take a Picture".
       const question: AyuQuestion = {
         linkId: 'q',
         text: 'Q',
@@ -379,7 +381,7 @@ describe('AyuPhysicalExamOptions', () => {
         ],
         answerOption: [
           {
-            valueCoding: { code: 'cam' }, // no display
+            valueCoding: { code: 'cam', display: '[picture taken]' },
             extension: [
               {
                 url: EXT_URL_PE_OPTION_KIND,
@@ -397,8 +399,11 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       expect(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: 'Take a Picture' })
       ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /picture taken/i })
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -473,7 +478,7 @@ describe('AyuPhysicalExamOptions', () => {
           setAnswer={setAnswer}
         />
       );
-      const camTile = screen.getByRole('button', { name: /Take a picture/ });
+      const camTile = screen.getByRole('button', { name: /Take a Picture/ });
       await userEvent.click(camTile);
       // Tile becomes selected, but the answer hasn't been written yet — that
       // happens on Submit (with images present).
@@ -489,7 +494,7 @@ describe('AyuPhysicalExamOptions', () => {
           setAnswer={vi.fn()}
         />
       );
-      const camTile = screen.getByRole('button', { name: /Take a picture/ });
+      const camTile = screen.getByRole('button', { name: /Take a Picture/ });
       await userEvent.click(camTile);
       await userEvent.click(camTile);
       expect(cameraState.clearCameraImages).toHaveBeenCalledWith(
@@ -518,7 +523,7 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       expect(
-        screen.queryByRole('button', { name: /Take a picture/ })
+        screen.queryByRole('button', { name: /Take a Picture/ })
       ).not.toBeInTheDocument();
     });
   });
@@ -533,7 +538,7 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       await userEvent.click(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       );
       await userEvent.click(screen.getByTestId('image-capture-add'));
       expect(cameraState.addCameraImage).toHaveBeenCalledWith(
@@ -559,7 +564,7 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       await userEvent.click(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       );
       // Submit button now visible, labelled with image count
       expect(
@@ -579,7 +584,7 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       await userEvent.click(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       );
       await userEvent.click(
         screen.getByRole('button', { name: /Upload \(1\)/ })
@@ -599,7 +604,7 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       await userEvent.click(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       );
       await userEvent.click(
         screen.getByRole('button', { name: /Upload \(1\)/ })
@@ -607,7 +612,7 @@ describe('AyuPhysicalExamOptions', () => {
       expect(setAnswer).toHaveBeenCalledWith(question, ['yes', 'cam']);
     });
 
-    it('Submit does nothing when no images have been captured', async () => {
+    it('shows an inline error and does not commit when Submit is clicked without images', async () => {
       const setAnswer = vi.fn();
       render(
         <AyuPhysicalExamOptions
@@ -617,16 +622,42 @@ describe('AyuPhysicalExamOptions', () => {
         />
       );
       await userEvent.click(
-        screen.getByRole('button', { name: /Take a picture/ })
+        screen.getByRole('button', { name: /Take a Picture/ })
       );
-      // No Submit visible because images.length === 0
+      // Submit button is visible even with 0 images so the user has a clear
+      // action; clicking it surfaces an inline error instead of failing
+      // silently.
+      const submit = screen.getByRole('button', { name: /Upload \(0\)/ });
+      await userEvent.click(submit);
       expect(
-        screen.queryByRole('button', { name: /Upload/ })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /^Submit$/ })
-      ).not.toBeInTheDocument();
+        screen.getByText('Please upload at least one image')
+      ).toBeInTheDocument();
       expect(setAnswer).not.toHaveBeenCalled();
+    });
+
+    it('clears the inline upload error once an image is added', async () => {
+      const setAnswer = vi.fn();
+      render(
+        <AyuPhysicalExamOptions
+          question={makePeQuestion()}
+          value={undefined}
+          setAnswer={setAnswer}
+        />
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /Take a Picture/ })
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /Upload \(0\)/ })
+      );
+      expect(
+        screen.getByText('Please upload at least one image')
+      ).toBeInTheDocument();
+      // Simulating an image add through the mocked PhysicalExamImageCapture
+      await userEvent.click(screen.getByTestId('image-capture-add'));
+      expect(
+        screen.queryByText('Please upload at least one image')
+      ).not.toBeInTheDocument();
     });
 
     it('does not render an inner Submit button for plain multi-choice (defers to outer stepper)', () => {

--- a/src/test/modules/ayu/components/start-visit/physical-examination.component.test.tsx
+++ b/src/test/modules/ayu/components/start-visit/physical-examination.component.test.tsx
@@ -541,7 +541,7 @@ describe('PhysicalExamination (AyuStepperContainer rewrite)', () => {
       expect(modalConfig.sections).toEqual([]);
     });
 
-    it('shows "Picture taken" when a camera answer has captured images', async () => {
+    it('shows "Picture Taken" when a camera answer has captured images', async () => {
       const user = userEvent.setup();
       const questions = [
         makeQuestion('with-images', 'General', 'Skin', [
@@ -557,7 +557,7 @@ describe('PhysicalExamination (AyuStepperContainer rewrite)', () => {
       capturedStepperProps._completeAnswers = { 'with-images': ['CAM'] };
       await user.click(screen.getByTestId('trigger-complete'));
       const modalConfig = mockShowVitalConfirmationModal.mock.calls[0][0];
-      expect(modalConfig.sections[0].items[0].value).toBe('Picture taken');
+      expect(modalConfig.sections[0].items[0].value).toBe('Picture Taken');
     });
 
     it('omits camera answers when there are no captured images', async () => {

--- a/src/test/modules/dashboard/open-visits.component.test.tsx
+++ b/src/test/modules/dashboard/open-visits.component.test.tsx
@@ -11,9 +11,14 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockUseOpenVisits = vi.fn();
+const mockUsePriorityVisits = vi.fn();
 
 vi.mock('../../../hooks/useOpenVisits', () => ({
   useOpenVisits: () => mockUseOpenVisits(),
+}));
+
+vi.mock('../../../hooks/usePriorityVisits', () => ({
+  usePriorityVisits: () => mockUsePriorityVisits(),
 }));
 
 const mockData = [
@@ -47,11 +52,31 @@ const mockData = [
   },
 ];
 
+const mockPriorityData = [
+  {
+    visitUuid: 'pv-1',
+    patientName: 'Anita Desai',
+    gender: 'F',
+    age: 42,
+    visitCreatedDate: '2025-04-20',
+    clinicName: 'TM Clinic 2',
+    uploadTimestamp: '1 hr ago',
+    isPriority: true,
+  },
+];
+
 const defaultState = {
   data: mockData,
   loading: false,
   error: null,
   totalCount: 3,
+};
+
+const defaultPriorityState = {
+  data: mockPriorityData,
+  loading: false,
+  error: null,
+  totalCount: 1,
 };
 
 const renderComponent = (props = {}) =>
@@ -65,6 +90,7 @@ describe('OpenVisitsComponent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseOpenVisits.mockReturnValue(defaultState);
+    mockUsePriorityVisits.mockReturnValue(defaultPriorityState);
   });
 
   describe('Initial render', () => {
@@ -342,39 +368,56 @@ describe('OpenVisitsComponent', () => {
       expect(openTab).toHaveClass('text-indigo-600');
     });
 
-    it('clicking Priority Visits filters to only priority rows', () => {
+    it('Priority Visits tab displays rows from the dedicated priority endpoint', () => {
       renderComponent();
       const priorityTab = screen
         .getByText('Priority Visits')
         .closest('button')!;
       fireEvent.click(priorityTab);
-      // Anita is the only priority visit in mockData
+      // Only Anita is present in the priority-visits payload; rows that exist
+      // in the open-visits payload must not bleed through.
       expect(screen.getAllByText('Anita Desai').length).toBeGreaterThan(0);
       expect(screen.queryByText('Ravi Kumar')).not.toBeInTheDocument();
       expect(screen.queryByText('Zara Malik')).not.toBeInTheDocument();
     });
 
-    it('shows "No priority visits found." when Priority tab has no rows', () => {
-      mockUseOpenVisits.mockReturnValue({
-        data: [
-          {
-            visitUuid: 'ov-only',
-            patientName: 'Plain Patient',
-            gender: 'M',
-            age: 40,
-            visitCreatedDate: '2025-04-21',
-            clinicName: 'TM Clinic 1',
-            uploadTimestamp: '5 min ago',
-          },
-        ],
+    it('shows "No priority visits found." when the priority endpoint returns no rows', () => {
+      mockUsePriorityVisits.mockReturnValue({
+        data: [],
         loading: false,
         error: null,
-        totalCount: 1,
+        totalCount: 0,
       });
       renderComponent();
       fireEvent.click(screen.getByText('Priority Visits').closest('button')!);
       expect(
         screen.getByText('No priority visits found.')
+      ).toBeInTheDocument();
+    });
+
+    it('Priority tab surfaces loading state from the priority hook', () => {
+      mockUsePriorityVisits.mockReturnValue({
+        data: [],
+        loading: true,
+        error: null,
+        totalCount: 0,
+      });
+      renderComponent();
+      fireEvent.click(screen.getByText('Priority Visits').closest('button')!);
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('Priority tab surfaces error from the priority hook', () => {
+      mockUsePriorityVisits.mockReturnValue({
+        data: [],
+        loading: false,
+        error: 'Failed to fetch priority visits',
+        totalCount: 0,
+      });
+      renderComponent();
+      fireEvent.click(screen.getByText('Priority Visits').closest('button')!);
+      expect(
+        screen.getByText('Failed to fetch priority visits')
       ).toBeInTheDocument();
     });
 

--- a/src/test/open-visits.component.test.tsx
+++ b/src/test/open-visits.component.test.tsx
@@ -11,9 +11,14 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockUseOpenVisits = vi.fn();
+const mockUsePriorityVisits = vi.fn();
 
 vi.mock('../hooks/useOpenVisits', () => ({
   useOpenVisits: () => mockUseOpenVisits(),
+}));
+
+vi.mock('../hooks/usePriorityVisits', () => ({
+  usePriorityVisits: () => mockUsePriorityVisits(),
 }));
 
 const mockData = [
@@ -52,6 +57,12 @@ describe('OpenVisitsComponent', () => {
       loading: false,
       error: null,
       totalCount: 2,
+    });
+    mockUsePriorityVisits.mockReturnValue({
+      data: [],
+      loading: false,
+      error: null,
+      totalCount: 0,
     });
   });
 

--- a/src/test/pages/open-visits/open-visits.page.test.tsx
+++ b/src/test/pages/open-visits/open-visits.page.test.tsx
@@ -6,6 +6,10 @@ vi.mock('../../../hooks/useOpenVisits', () => ({
   useOpenVisits: () => ({ data: [], loading: false, error: null, totalCount: 0 }),
 }));
 
+vi.mock('../../../hooks/usePriorityVisits', () => ({
+  usePriorityVisits: () => ({ data: [], loading: false, error: null, totalCount: 0 }),
+}));
+
 import OpenVisitsPage from '../../../pages/open-visits/open-visits.page';
 
 describe('OpenVisitsPage', () => {

--- a/src/test/services/patient.service.test.ts
+++ b/src/test/services/patient.service.test.ts
@@ -162,6 +162,34 @@ describe('patientService', () => {
     });
   });
 
+  describe('getPriorityVisits', () => {
+    it('calls the correct URL and returns visits', async () => {
+      const mockVisits = [
+        { visitUuid: 'pv-1', patientName: 'Anita Desai', gender: 'F', visitCreatedDate: '2025-04-20', clinicName: 'TC 2', uploadTimestamp: '1h', isPriority: true },
+      ];
+      h.mockGet.mockResolvedValue({ data: { status: 'success', data: { visits: mockVisits, totalCount: 1, pageNo: 0, pageSize: 50 } } });
+
+      const result = await patientService.getPriorityVisits('hw-123');
+
+      expect(h.mockGet).toHaveBeenCalledWith('/pull/hw-visits/hw-123?type=priority-visits&page=0&limit=50', undefined);
+      expect(result).toEqual({ visits: mockVisits, totalCount: 1 });
+    });
+
+    it('passes custom page and limit', async () => {
+      h.mockGet.mockResolvedValue({ data: { status: 'success', data: { visits: [], totalCount: 0, pageNo: 4, pageSize: 25 } } });
+
+      await patientService.getPriorityVisits('hw-321', 4, 25);
+
+      expect(h.mockGet).toHaveBeenCalledWith('/pull/hw-visits/hw-321?type=priority-visits&page=4&limit=25', undefined);
+    });
+
+    it('propagates errors from the API', async () => {
+      h.mockGet.mockRejectedValue(new Error('Server error'));
+
+      await expect(patientService.getPriorityVisits('hw-123')).rejects.toThrow('Server error');
+    });
+  });
+
   describe('getPrescriptionsPending', () => {
     it('calls the correct URL and returns visits', async () => {
       const mockVisits = [


### PR DESCRIPTION
…lidation; add priority-visits endpoint

Physical exam:
- Camera tile always renders "Take a Picture" (no longer leaks the "[picture taken]" marker from the FHIR language extension)
- Answered card and summary modal render "Picture Taken" via the camera option's stored display
- Inline error "Please upload at least one image" when Submit is clicked with the camera tile selected but no images captured; Submit button is now visible as soon as the tile is selected
- Job-aid reference image/video constrained to max-w-xs so larger source files no longer render oversized
- Deduplicate "[picture taken]" sentinel answerOptions so a single camera tile renders; filter is keyed on the language marker so Yes/No questions whose attachment enables on the real answer codes are not stripped

Priority visits:
- New GET /pull/hw-visits/{hwId}?type=priority-visits endpoint wired via patientService.getPriorityVisits and usePriorityVisits
- Open Visits dashboard switches data source by active tab instead of filtering the open-visits payload on isPriority client-side

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] All pre-commit checks pass

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No console errors or warnings
- [ ] Responsive design tested (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer**: @Zeeshan-IH
**Assignee**: @Zeeshan-IH
