### PR TITLE
feat(visit-summary): show additional vital measurements and patient header

### DIFF
--- a/src/assets/data/visit-summary.data.ts
+++ b/src/assets/data/visit-summary.data.ts
@@ -12,6 +12,15 @@ export const CONCEPT_UUIDS = {
   TEMPERATURE: '5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   SPO2: '5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   RESPIRATORY_RATE: '5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  FBS: '2d6845e6-fa7a-4a80-a55a-c4fa6ff4e2af',
+  PPBS: 'e2d331f0-3132-4b66-9137-b1f9ace65443',
+  RBS: '056f3911-55ee-42c4-8078-5537a620a35a',
+  WAIST_CIRCUMFERENCE: '41e7d3ff-d24b-448f-a248-a4feb64ef700',
+  HIP_CIRCUMFERENCE: '9f1b264f-2b9b-44f5-9d7a-c809e9f63c51',
+  WAIST_TO_HIP_RATIO: '20d3e924-f379-443d-9033-c8d1cdfda2f0',
+  OGTT: 'd7a564d7-f104-4186-8e36-68101c7c2952',
+  HBA1C: 'f0631271-e0b3-48ca-a4e5-70959a7b76d9',
+  BLOOD_GROUP: '9d2df0c6-538f-11e6-9cfe-86f436325720',
   CHIEF_COMPLAINT: '3edb0e09-9135-481e-b8f0-07a26fa9a5ce',
   PHYSICAL_EXAMINATION: '200b7a45-77bc-4986-b879-cc727f5f7d5b',
   PHYSICAL_EXAM_DISPLAY: 'e1761e85-9b50-48ae-8c4d-e6b7eeeba084',
@@ -60,6 +69,11 @@ export interface BMI {
   value: number;
 }
 
+export interface AdditionalMeasurement {
+  label: string;
+  value: string;
+}
+
 export interface Vitals {
   height: VitalValue;
   weight: VitalValue;
@@ -69,6 +83,7 @@ export interface Vitals {
   temperature: VitalValue;
   spo2: VitalValue;
   respiratoryRate: VitalValue;
+  additionalMeasurements?: AdditionalMeasurement[];
 }
 
 export interface Detail {

--- a/src/modules/ayu/pages/visit-summary.page.tsx
+++ b/src/modules/ayu/pages/visit-summary.page.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import type {
   CheckupReason,
@@ -19,6 +25,7 @@ import type { ModalSectionItem } from '../../../components/modal/global-modal-co
 import { useProfileContext } from '../../../context/ProfileContext';
 import { useConfig } from '../../../hooks/useConfig';
 import { showToast } from '../../../services/toast';
+import { patientService } from '../../patient/add/add-patient.service';
 import { storage } from '../../../utils/storage';
 import CollapsedComponent from '../../visit-summary/visit-summary-collapsed.component';
 import { ENCOUNTER_TYPES } from '../constants/visit-upload.constants';
@@ -43,7 +50,7 @@ import {
 } from '../services/visit-upload.service';
 import type { CapturedDocument } from '../types/obs.types';
 import { ACCEPTED_DOCUMENT_TYPES } from '../types/obs.types';
-import type { VitalsFormValues } from '../types/vitals.types';
+import type { VitalField, VitalsFormValues } from '../types/vitals.types';
 import {
   AYU_JSON_KEY_NAME,
   ITEM_TYPES,
@@ -58,6 +65,69 @@ import {
 } from '../utils/parseFhirPhysExamQuestionnaire';
 
 const PRIMARY_COLOR = '#0fd197';
+
+const VITALS_PRIMARY_KEYS = new Set([
+  'height_cm',
+  'weight_kg',
+  'bmi',
+  'bp_systolic',
+  'bp_diastolic',
+  'pulse_bpm',
+  'respiratory_rate',
+  'temprature_f',
+  'spo2',
+]);
+
+const buildAdditionalMeasurements = (
+  config: VitalField[],
+  formValues: VitalsFormValues
+): { label: string; value: string }[] => {
+  return config
+    .filter(field => !VITALS_PRIMARY_KEYS.has(field.key))
+    .map(field => {
+      const raw = (formValues as Record<string, unknown>)[field.key];
+      let display = 'No information';
+      if (raw != null && raw !== '') {
+        if (field.key === 'blood_group') {
+          const match = field.answers?.find(a => a.uuid === String(raw));
+          display = match?.display ?? String(raw);
+        } else {
+          display = String(raw);
+        }
+      }
+      return { label: field.name, value: display };
+    });
+};
+
+const AdditionalMeasurementsSection: React.FC<{
+  items: { label: string; value: string }[];
+}> = ({ items }) => {
+  if (items.length === 0) return null;
+  const mid = Math.ceil(items.length / 2);
+  const leftItems = items.slice(0, mid);
+  const rightItems = items.slice(mid);
+  return (
+    <div className="mt-4">
+      <p className="text-sm font-semibold text-gray-500 mb-2">
+        Additional Measurements
+      </p>
+      <div className="md:hidden">
+        {items.map(({ label, value }) => (
+          <LabelValueRow key={label} label={label} value={value} />
+        ))}
+      </div>
+      <div className="hidden md:grid grid-cols-2 gap-x-10">
+        {[leftItems, rightItems].map((column, colIdx) => (
+          <div key={colIdx}>
+            {column.map(({ label, value }) => (
+              <LabelValueRow key={label} label={label} value={value} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const LabelValueRow: React.FC<{
   label: string;
@@ -255,7 +325,38 @@ const VisitSummaryPage = () => {
   const [additionalDocuments, setAdditionalDocuments] = useState<
     CapturedDocument[]
   >([]);
+  const [patientName, setPatientName] = useState<string>('');
+  const [patientIdentifier, setPatientIdentifier] = useState<string>('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const uuid = ctxPatientUuid || storage.get(PATIENT_UUID_KEY);
+    if (!uuid) return;
+    let cancelled = false;
+    patientService
+      .getPatient(uuid)
+      .then(patient => {
+        if (cancelled) return;
+        const pn = patient.person?.preferredName;
+        const fullName = pn
+          ? [pn.givenName, pn.middleName, pn.familyName]
+              .filter(Boolean)
+              .join(' ')
+              .trim()
+          : '';
+        const preferred =
+          patient.identifiers?.find(i => i.preferred) ??
+          patient.identifiers?.[0];
+        setPatientName(fullName || storage.get(PATIENT_NAME_KEY) || '');
+        setPatientIdentifier(preferred?.identifier ?? '');
+      })
+      .catch(() => {
+        setPatientName(storage.get(PATIENT_NAME_KEY) ?? '');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ctxPatientUuid]);
 
   const toggleAll = useCallback(() => setAllOpen(prev => !prev), []);
 
@@ -417,6 +518,17 @@ const VisitSummaryPage = () => {
     [data.vitals]
   );
 
+  const additionalMeasurements = useMemo(
+    () =>
+      data.vitals
+        ? buildAdditionalMeasurements(
+            data.vitals.config,
+            data.vitals.formValues
+          )
+        : [],
+    [data.vitals]
+  );
+
   const checkupReason = useMemo(
     (): CheckupReason | null =>
       data.visitReason
@@ -445,6 +557,20 @@ const VisitSummaryPage = () => {
           Visit Summary
         </span>
       </div>
+      {(patientName || patientIdentifier) && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 md:px-0 mt-1 mb-2">
+          {patientName && (
+            <span className="text-sm font-semibold text-gray-800">
+              {patientName}
+            </span>
+          )}
+          {patientIdentifier && (
+            <span className="text-xs text-gray-500">
+              OpenMRS ID: {patientIdentifier}
+            </span>
+          )}
+        </div>
+      )}
       <hr className="border-t border-gray-200 mt-2 mb-3 md:-mx-4" />
 
       <div className="px-4 md:px-0">
@@ -472,7 +598,12 @@ const VisitSummaryPage = () => {
               key={`vitals-${allOpen}`}
             >
               {vitals ? (
-                <VitalsSection vitals={vitals} />
+                <>
+                  <VitalsSection vitals={vitals} />
+                  <AdditionalMeasurementsSection
+                    items={additionalMeasurements}
+                  />
+                </>
               ) : (
                 <p className="text-gray-400 italic text-sm">
                   No vitals recorded

--- a/src/modules/visit-summary/visit-summary.component.tsx
+++ b/src/modules/visit-summary/visit-summary.component.tsx
@@ -203,6 +203,11 @@ const VitalsSection: React.FC<{ vitals: Vitals }> = ({ vitals }) => {
   const leftItems = items.slice(0, 4);
   const rightItems = items.slice(4);
 
+  const additional = vitals.additionalMeasurements ?? [];
+  const addMid = Math.ceil(additional.length / 2);
+  const addLeft = additional.slice(0, addMid);
+  const addRight = additional.slice(addMid);
+
   return (
     <>
       <div className="md:hidden">
@@ -220,6 +225,28 @@ const VitalsSection: React.FC<{ vitals: Vitals }> = ({ vitals }) => {
           </div>
         ))}
       </div>
+
+      {additional.length > 0 && (
+        <div className="mt-4">
+          <p className="text-sm font-semibold text-gray-500 mb-2">
+            Additional Measurements
+          </p>
+          <div className="md:hidden">
+            {additional.map(({ label, value }) => (
+              <LabelValueRow key={label} label={label} value={value} />
+            ))}
+          </div>
+          <div className="hidden md:grid grid-cols-2 gap-x-10">
+            {[addLeft, addRight].map((column, colIdx) => (
+              <div key={colIdx}>
+                {column.map(({ label, value }) => (
+                  <LabelValueRow key={label} label={label} value={value} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/src/modules/visit-summary/visit-summary.service.ts
+++ b/src/modules/visit-summary/visit-summary.service.ts
@@ -33,6 +33,57 @@ interface CloseVisitPayload {
   stopDatetime: string;
 }
 
+const ADDITIONAL_MEASUREMENT_CONCEPTS: { uuid: string; label: string }[] = [
+  { uuid: CONCEPT_UUIDS.FBS, label: 'Fasting Blood Sugar (FBS) (mg/dl)' },
+  {
+    uuid: CONCEPT_UUIDS.PPBS,
+    label: 'Post Prandial Blood Sugar (PPBS) (mg/dl)',
+  },
+  { uuid: CONCEPT_UUIDS.RBS, label: 'RBS (mg/dl)' },
+  {
+    uuid: CONCEPT_UUIDS.WAIST_CIRCUMFERENCE,
+    label: 'Waist Circumference (cm)',
+  },
+  { uuid: CONCEPT_UUIDS.HIP_CIRCUMFERENCE, label: 'Hip Circumference (cm)' },
+  { uuid: CONCEPT_UUIDS.WAIST_TO_HIP_RATIO, label: 'Waist to Hip Ratio (WHR)' },
+  {
+    uuid: CONCEPT_UUIDS.OGTT,
+    label: '2 Hour Post Load Glucose Test (OGTT) (mg/dl)',
+  },
+  { uuid: CONCEPT_UUIDS.HBA1C, label: 'HbA1c' },
+  { uuid: CONCEPT_UUIDS.BLOOD_GROUP, label: 'Blood Group' },
+];
+
+function getObsRawDisplay(
+  encounters: VisitDetailsEncounter[],
+  conceptUuid: string
+): string | null {
+  for (const encounter of encounters) {
+    for (const obs of encounter.obs) {
+      if (obs.concept?.uuid === conceptUuid) {
+        const v = obs.value;
+        if (v == null) return null;
+        if (typeof v === 'number') return String(v);
+        if (typeof v === 'string') return v;
+        if (typeof v === 'object' && 'display' in v) {
+          return (v as { display?: string }).display ?? null;
+        }
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+export function extractAdditionalMeasurements(
+  encounters: VisitDetailsEncounter[]
+): { label: string; value: string }[] {
+  return ADDITIONAL_MEASUREMENT_CONCEPTS.map(({ uuid, label }) => {
+    const raw = getObsRawDisplay(encounters, uuid);
+    return { label, value: raw ?? 'No information' };
+  }).filter(item => item.value !== 'No information');
+}
+
 export function getObsNumericValue(
   encounters: VisitDetailsEncounter[],
   conceptUuid: string
@@ -419,6 +470,7 @@ export function transformVisitSummaryResponse(
         unit: 'breaths/min',
         ...(respiratoryRate === null ? { note: 'No information' } : {}),
       },
+      additionalMeasurements: extractAdditionalMeasurements(encounters),
     },
     checkupReason: chiefComplaintData,
     physicalExamination,

--- a/src/test/modules/ayu/pages/visit-summary.page.test.tsx
+++ b/src/test/modules/ayu/pages/visit-summary.page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /* ── Mock navigation ─────────────────────────────────────────────────────── */
 
@@ -134,6 +134,15 @@ vi.mock('../../../../modules/ayu/services/visit-upload.service', () => ({
 const mockBulkMarkSynced = vi.fn();
 vi.mock('../../../../modules/ayu/services/temp-storage.service', () => ({
   bulkMarkSynced: (...args: any[]) => mockBulkMarkSynced(...args),
+}));
+
+
+
+const mockGetPatient = vi.fn();
+vi.mock('../../../../modules/patient/add/add-patient.service', () => ({
+  patientService: {
+    getPatient: (...args: any[]) => mockGetPatient(...args),
+  },
 }));
 
 /* ── Mock obs.service ──────────────────────────────────────────────────── */
@@ -291,6 +300,11 @@ beforeEach(() => {
   mockUseConfig.mockReturnValue({ config: defaultMockConfig });
   mockUploadAllAdditionalDocuments.mockResolvedValue(undefined);
   mockGetLatestVisitUuid.mockResolvedValue('mock-visit-uuid');
+  mockGetPatient.mockResolvedValue({
+    uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    identifiers: [],
+    person: { preferredName: null, attributes: [] },
+  });
 });
 
 describe('VisitSummaryPage', () => {
@@ -1560,6 +1574,387 @@ describe('VisitSummaryPage', () => {
         'Visit uploaded successfully',
         'success'
       );
+    });
+  });
+
+
+  describe('Additional Measurements', () => {
+    it('should not render the heading when config has no additional fields', () => {
+      renderWithData({ vitals: fullData.vitals });
+      expect(
+        screen.queryByText('Additional Measurements')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render additional measurement labels and values from config', () => {
+      renderWithData({
+        vitals: {
+          formValues: {
+            ...fullData.vitals.formValues,
+            fbs_mg_per_dl: 89,
+            hba1c: 6,
+          },
+          config: [
+            {
+              name: 'Fasting Blood Sugar (FBS) (mg/dl)',
+              key: 'fbs_mg_per_dl',
+              uuid: 'fbs-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+            },
+            {
+              name: 'HbA1c',
+              key: 'hba1c',
+              uuid: 'hba1c-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+            },
+          ],
+        },
+      });
+      expect(screen.getByText('Additional Measurements')).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Fasting Blood Sugar (FBS) (mg/dl)').length
+      ).toBeGreaterThan(0);
+      expect(screen.getAllByText('89').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('HbA1c').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('6').length).toBeGreaterThan(0);
+    });
+
+    it('should show "No information" when value is missing for an additional field', () => {
+      renderWithData({
+        vitals: {
+          formValues: { ...fullData.vitals.formValues },
+          config: [
+            {
+              name: 'HbA1c',
+              key: 'hba1c',
+              uuid: 'hba1c-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+            },
+          ],
+        },
+      });
+      expect(screen.getByText('Additional Measurements')).toBeInTheDocument();
+      expect(screen.getAllByText('HbA1c').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('No information').length).toBeGreaterThan(0);
+    });
+
+    it('should resolve blood_group uuid to its display name via config answers', () => {
+      renderWithData({
+        vitals: {
+          formValues: {
+            ...fullData.vitals.formValues,
+            blood_group: 'bg-uuid-bpos',
+          },
+          config: [
+            {
+              name: 'Blood Group',
+              key: 'blood_group',
+              uuid: 'blood-group-concept-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+              datatype: 'Coded',
+              answers: [
+                { uuid: 'bg-uuid-bpos', display: 'B POSITIVE' },
+                { uuid: 'bg-uuid-apos', display: 'A POSITIVE' },
+              ],
+            },
+          ],
+        },
+      });
+      expect(screen.getByText('Additional Measurements')).toBeInTheDocument();
+      expect(screen.getAllByText('Blood Group').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('B POSITIVE').length).toBeGreaterThan(0);
+    });
+
+    it('should fall back to raw uuid when blood_group has no matching answer', () => {
+      renderWithData({
+        vitals: {
+          formValues: {
+            ...fullData.vitals.formValues,
+            blood_group: 'unknown-uuid',
+          },
+          config: [
+            {
+              name: 'Blood Group',
+              key: 'blood_group',
+              uuid: 'blood-group-concept-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+              datatype: 'Coded',
+              answers: [{ uuid: 'bg-uuid-bpos', display: 'B POSITIVE' }],
+            },
+          ],
+        },
+      });
+      expect(screen.getAllByText('unknown-uuid').length).toBeGreaterThan(0);
+    });
+
+    it('should fall back to raw uuid when blood_group config has no answers', () => {
+      renderWithData({
+        vitals: {
+          formValues: {
+            ...fullData.vitals.formValues,
+            blood_group: 'orphan-uuid',
+          },
+          config: [
+            {
+              name: 'Blood Group',
+              key: 'blood_group',
+              uuid: 'blood-group-concept-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+              datatype: 'Coded',
+            },
+          ],
+        },
+      });
+      expect(screen.getAllByText('orphan-uuid').length).toBeGreaterThan(0);
+    });
+
+    it('should treat empty-string value as missing', () => {
+      renderWithData({
+        vitals: {
+          formValues: {
+            ...fullData.vitals.formValues,
+            hba1c: '' as unknown as number,
+          },
+          config: [
+            {
+              name: 'HbA1c',
+              key: 'hba1c',
+              uuid: 'hba1c-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+            },
+          ],
+        },
+      });
+      expect(screen.getAllByText('No information').length).toBeGreaterThan(0);
+    });
+
+    it('should exclude primary vitals fields from Additional Measurements', () => {
+      renderWithData({
+        vitals: {
+          formValues: fullData.vitals.formValues,
+          config: [
+            {
+              name: 'Height (cm)',
+              key: 'height_cm',
+              uuid: 'height-uuid',
+              is_mandatory: true,
+              lang: null,
+              is_enabled: true,
+            },
+            {
+              name: 'HbA1c',
+              key: 'hba1c',
+              uuid: 'hba1c-uuid',
+              is_mandatory: false,
+              lang: null,
+              is_enabled: true,
+            },
+          ],
+        },
+      });
+      
+      expect(screen.getByText('Additional Measurements')).toBeInTheDocument();
+      expect(screen.getAllByText('HbA1c').length).toBeGreaterThan(0);
+    });
+  });
+
+ 
+
+  describe('Patient header (name + OpenMRS ID)', () => {
+    it('should fetch and display patient name and OpenMRS ID', async () => {
+      mockGetPatient.mockResolvedValueOnce({
+        uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        identifiers: [
+          { identifier: 'AB123', preferred: false },
+          { identifier: 'OMRS-001', preferred: true },
+        ],
+        person: {
+          preferredName: {
+            givenName: 'Jane',
+            middleName: 'M',
+            familyName: 'Smith',
+          },
+          attributes: [],
+        },
+      });
+      renderWithData();
+      await waitFor(() => {
+        expect(screen.getByText('Jane M Smith')).toBeInTheDocument();
+        expect(
+          screen.getByText('OpenMRS ID: OMRS-001')
+        ).toBeInTheDocument();
+      });
+      expect(mockGetPatient).toHaveBeenCalledWith(
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      );
+    });
+
+    it('should fall back to first identifier when no preferred flag is set', async () => {
+      mockGetPatient.mockResolvedValueOnce({
+        uuid: 'patient-uuid',
+        identifiers: [
+          { identifier: 'FIRST-ID', preferred: false },
+          { identifier: 'SECOND-ID', preferred: false },
+        ],
+        person: {
+          preferredName: { givenName: 'John', middleName: null, familyName: 'Doe' },
+          attributes: [],
+        },
+      });
+      renderWithData();
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument();
+        expect(screen.getByText('OpenMRS ID: FIRST-ID')).toBeInTheDocument();
+      });
+    });
+
+    it('should skip fetch and render no header when patient uuid is absent', async () => {
+      mockUseStartVisitData.mockReturnValueOnce({
+        data: { ...defaultData },
+        patientUuid: null as unknown as string,
+        visitId: 'test-visit-id',
+        tempRecordId: null,
+        restoredSectionIndex: null,
+        lastSectionIndex: 0,
+        setLastSectionIndex: vi.fn(),
+        setPatientUuid: vi.fn(),
+        setVitalsData: vi.fn(),
+        setVisitReasonData: vi.fn(),
+        setPhysicalExamData: vi.fn(),
+        setMedicalHistoryData: vi.fn(),
+        setMedicalHistoryAnswers: vi.fn(),
+        saveSectionToTemp: mockSaveSectionToTemp,
+        clearVisitId: mockClearVisitId,
+      });
+      mockStorageGet.mockReturnValue(null);
+      render(<VisitSummaryPage />);
+      expect(mockGetPatient).not.toHaveBeenCalled();
+      expect(screen.queryByText(/OpenMRS ID:/)).not.toBeInTheDocument();
+    });
+
+    it('should fall back to storage name when getPatient fails', async () => {
+      mockGetPatient.mockRejectedValueOnce(new Error('network'));
+      mockStorageGet.mockImplementation((key: string) =>
+        key === 'patientName' ? 'Cached Patient' : null
+      );
+      renderWithData();
+      await waitFor(() => {
+        expect(screen.getByText('Cached Patient')).toBeInTheDocument();
+      });
+      // No identifier known on fallback
+      expect(screen.queryByText(/OpenMRS ID:/)).not.toBeInTheDocument();
+    });
+
+    it('should render no header when getPatient fails and storage has no name', async () => {
+      mockGetPatient.mockRejectedValueOnce(new Error('network'));
+      mockStorageGet.mockReturnValue(null);
+      renderWithData();
+      await waitFor(() => {
+        expect(mockGetPatient).toHaveBeenCalled();
+      });
+      expect(screen.queryByText(/OpenMRS ID:/)).not.toBeInTheDocument();
+    });
+
+    it('should fall back to storage name when preferredName is null', async () => {
+      mockGetPatient.mockResolvedValueOnce({
+        uuid: 'patient-uuid',
+        identifiers: [{ identifier: 'OMRS-XYZ', preferred: true }],
+        person: { preferredName: null, attributes: [] },
+      });
+      mockStorageGet.mockImplementation((key: string) =>
+        key === 'patientName' ? 'Stored Name' : null
+      );
+      renderWithData();
+      await waitFor(() => {
+        expect(screen.getByText('Stored Name')).toBeInTheDocument();
+        expect(screen.getByText('OpenMRS ID: OMRS-XYZ')).toBeInTheDocument();
+      });
+    });
+
+    it('should render nothing when name and identifier are both empty', async () => {
+      mockGetPatient.mockResolvedValueOnce({
+        uuid: 'patient-uuid',
+        identifiers: [],
+        person: { preferredName: null, attributes: [] },
+      });
+      renderWithData();
+      await waitFor(() => {
+        expect(mockGetPatient).toHaveBeenCalled();
+      });
+      expect(screen.queryByText(/OpenMRS ID:/)).not.toBeInTheDocument();
+    });
+
+    it('should not call setState after unmount when fetch resolves', async () => {
+      let resolveFn: (v: unknown) => void = () => {};
+      mockGetPatient.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveFn = resolve;
+        })
+      );
+      const { unmount } = renderWithData();
+      unmount();
+      resolveFn({
+        uuid: 'patient-uuid',
+        identifiers: [{ identifier: 'OMRS-001', preferred: true }],
+        person: {
+          preferredName: { givenName: 'Late', middleName: null, familyName: 'Patient' },
+          attributes: [],
+        },
+      });
+     
+      await new Promise(r => setTimeout(r, 0));
+      expect(screen.queryByText(/Late Patient/)).not.toBeInTheDocument();
+    });
+
+    it('should fall back to PATIENT_UUID_KEY from storage when ctx patientUuid is absent', async () => {
+      mockUseStartVisitData.mockReturnValueOnce({
+        data: { ...defaultData },
+        patientUuid: null as any,
+        visitId: 'test-visit-id',
+        tempRecordId: null,
+        restoredSectionIndex: null,
+        lastSectionIndex: 0,
+        setLastSectionIndex: vi.fn(),
+        setPatientUuid: vi.fn(),
+        setVitalsData: vi.fn(),
+        setVisitReasonData: vi.fn(),
+        setPhysicalExamData: vi.fn(),
+        setMedicalHistoryData: vi.fn(),
+        setMedicalHistoryAnswers: vi.fn(),
+        saveSectionToTemp: mockSaveSectionToTemp,
+        clearVisitId: mockClearVisitId,
+      });
+      mockStorageGet.mockImplementation((key: string) =>
+        key === 'patientUuid' ? 'storage-patient-uuid' : null
+      );
+      mockGetPatient.mockResolvedValueOnce({
+        uuid: 'storage-patient-uuid',
+        identifiers: [{ identifier: 'STO-001', preferred: true }],
+        person: {
+          preferredName: { givenName: 'From', middleName: null, familyName: 'Storage' },
+          attributes: [],
+        },
+      });
+      render(<VisitSummaryPage />);
+      await waitFor(() => {
+        expect(mockGetPatient).toHaveBeenCalledWith('storage-patient-uuid');
+        expect(screen.getByText('From Storage')).toBeInTheDocument();
+        expect(screen.getByText('OpenMRS ID: STO-001')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/test/modules/visit-summary/visit-summary.component.test.tsx
+++ b/src/test/modules/visit-summary/visit-summary.component.test.tsx
@@ -282,6 +282,43 @@ describe('VisitSummaryComponent', () => {
         expect(screen.getByText('Details')).toBeInTheDocument();
       });
     });
+
+    it('should not render Additional Measurements heading when none present', async () => {
+      renderWithMockData();
+      await waitFor(() => {
+        expect(screen.getByText('Details')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Additional Measurements')).not.toBeInTheDocument();
+    });
+
+    it('should render Additional Measurements when provided', async () => {
+      const originalData = [...visitSummaryDataModule.visitSummaryData];
+      visitSummaryDataModule.visitSummaryData[0] = {
+        ...originalData[0],
+        vitals: {
+          ...originalData[0].vitals,
+          additionalMeasurements: [
+            { label: 'Fasting Blood Sugar (FBS) (mg/dl)', value: '89' },
+            { label: 'HbA1c', value: '6' },
+            { label: 'Blood Group', value: 'B POSITIVE' },
+          ],
+        },
+      };
+
+      renderWithMockData();
+      await waitFor(() => {
+        expect(screen.getAllByText('Additional Measurements').length).toBeGreaterThan(0);
+        expect(
+          screen.getAllByText('Fasting Blood Sugar (FBS) (mg/dl)').length
+        ).toBeGreaterThan(0);
+        expect(screen.getAllByText('89').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('HbA1c').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('B POSITIVE').length).toBeGreaterThan(0);
+      });
+
+      visitSummaryDataModule.visitSummaryData.length = 0;
+      visitSummaryDataModule.visitSummaryData.push(...originalData);
+    });
   });
 
   describe('CheckupReasonSection', () => {

--- a/src/test/modules/visit-summary/visit-summary.service.test.ts
+++ b/src/test/modules/visit-summary/visit-summary.service.test.ts
@@ -8,6 +8,7 @@ import {
   extractChiefComplaints,
   extractPhysicalExamination,
   extractMedicalHistory,
+  extractAdditionalMeasurements,
   transformVisitSummaryResponse,
   transformObsToDocuments,
 } from '../../../modules/visit-summary/visit-summary.service';
@@ -1434,6 +1435,181 @@ describe('visitSummaryService', () => {
         responseType: 'blob',
       });
       expect(result).toBe(mockBlob);
+    });
+  });
+
+  describe('extractAdditionalMeasurements', () => {
+    it('should return empty array when no encounters', () => {
+      expect(extractAdditionalMeasurements([])).toEqual([]);
+    });
+
+    it('should return empty array when no matching concepts are present', () => {
+      const encounters = [
+        makeEncounter([makeObs(CONCEPT_UUIDS.HEIGHT, '170')]),
+      ];
+      expect(extractAdditionalMeasurements(encounters)).toEqual([]);
+    });
+
+    it('should extract numeric obs values for additional measurements', () => {
+      const encounters = [
+        makeEncounter([
+          makeObs(CONCEPT_UUIDS.FBS, '89'),
+          makeObs(CONCEPT_UUIDS.PPBS, '158'),
+          makeObs(CONCEPT_UUIDS.RBS, '112'),
+          makeObs(CONCEPT_UUIDS.WAIST_CIRCUMFERENCE, '80'),
+          makeObs(CONCEPT_UUIDS.HIP_CIRCUMFERENCE, '90'),
+          makeObs(CONCEPT_UUIDS.WAIST_TO_HIP_RATIO, '0.89'),
+          makeObs(CONCEPT_UUIDS.OGTT, '140'),
+          makeObs(CONCEPT_UUIDS.HBA1C, '6'),
+        ]),
+      ];
+      const result = extractAdditionalMeasurements(encounters);
+      expect(result).toEqual([
+        { label: 'Fasting Blood Sugar (FBS) (mg/dl)', value: '89' },
+        { label: 'Post Prandial Blood Sugar (PPBS) (mg/dl)', value: '158' },
+        { label: 'RBS (mg/dl)', value: '112' },
+        { label: 'Waist Circumference (cm)', value: '80' },
+        { label: 'Hip Circumference (cm)', value: '90' },
+        { label: 'Waist to Hip Ratio (WHR)', value: '0.89' },
+        { label: '2 Hour Post Load Glucose Test (OGTT) (mg/dl)', value: '140' },
+        { label: 'HbA1c', value: '6' },
+      ]);
+    });
+
+    it('should resolve coded blood group via value.display', () => {
+      const encounters = [
+        makeEncounter([
+          makeObs(CONCEPT_UUIDS.BLOOD_GROUP, {
+            uuid: 'bg-uuid',
+            display: 'B POSITIVE',
+          }),
+        ]),
+      ];
+      const result = extractAdditionalMeasurements(encounters);
+      expect(result).toEqual([{ label: 'Blood Group', value: 'B POSITIVE' }]);
+    });
+
+    it('should handle raw numeric obs value (not stringified)', () => {
+      const encounters: VisitDetailsEncounter[] = [
+        {
+          uuid: 'enc-uuid',
+          display: 'encounter',
+          encounterDatetime: '2026-01-15T10:00:00.000+0000',
+          encounterType: { uuid: 'et-uuid', display: 'Vitals' },
+          encounterProviders: [],
+          obs: [
+            {
+              uuid: 'obs-uuid',
+              display: 'FBS: 89',
+              concept: { uuid: CONCEPT_UUIDS.FBS, display: 'FBS' },
+              value: 89 as unknown as string,
+            },
+          ],
+        },
+      ];
+      const result = extractAdditionalMeasurements(encounters);
+      expect(result).toEqual([
+        { label: 'Fasting Blood Sugar (FBS) (mg/dl)', value: '89' },
+      ]);
+    });
+
+    it('should skip obs with null value', () => {
+      const encounters: VisitDetailsEncounter[] = [
+        {
+          uuid: 'enc-uuid',
+          display: 'encounter',
+          encounterDatetime: '2026-01-15T10:00:00.000+0000',
+          encounterType: { uuid: 'et-uuid', display: 'Vitals' },
+          encounterProviders: [],
+          obs: [
+            {
+              uuid: 'obs-uuid',
+              display: 'FBS',
+              concept: { uuid: CONCEPT_UUIDS.FBS, display: 'FBS' },
+              value: null as unknown as string,
+            },
+          ],
+        },
+      ];
+      expect(extractAdditionalMeasurements(encounters)).toEqual([]);
+    });
+
+    it('should skip obs whose object value lacks a display field', () => {
+      const encounters: VisitDetailsEncounter[] = [
+        {
+          uuid: 'enc-uuid',
+          display: 'encounter',
+          encounterDatetime: '2026-01-15T10:00:00.000+0000',
+          encounterType: { uuid: 'et-uuid', display: 'Vitals' },
+          encounterProviders: [],
+          obs: [
+            {
+              uuid: 'obs-uuid',
+              display: 'BG',
+              concept: {
+                uuid: CONCEPT_UUIDS.BLOOD_GROUP,
+                display: 'Blood Group',
+              },
+              value: { uuid: 'bg-uuid' } as unknown as string,
+            },
+          ],
+        },
+      ];
+      expect(extractAdditionalMeasurements(encounters)).toEqual([]);
+    });
+
+    it('should treat object value with undefined display as missing', () => {
+      const encounters = [
+        makeEncounter([
+          makeObs(CONCEPT_UUIDS.BLOOD_GROUP, {
+            uuid: 'bg-uuid',
+            display: undefined as unknown as string,
+          }),
+        ]),
+      ];
+      expect(extractAdditionalMeasurements(encounters)).toEqual([]);
+    });
+  });
+
+  describe('transformVisitSummaryResponse — additionalMeasurements', () => {
+    it('should populate vitals.additionalMeasurements from encounter obs', () => {
+      const response = makeResponse({
+        encounters: [
+          makeEncounter([
+            makeObs(CONCEPT_UUIDS.FBS, '89'),
+            makeObs(CONCEPT_UUIDS.HBA1C, '6'),
+            makeObs(CONCEPT_UUIDS.BLOOD_GROUP, {
+              uuid: 'bg-uuid',
+              display: 'B POSITIVE',
+            }),
+          ]),
+        ],
+      });
+      const result = transformVisitSummaryResponse(response);
+      expect(result.vitals.additionalMeasurements).toEqual([
+        { label: 'Fasting Blood Sugar (FBS) (mg/dl)', value: '89' },
+        { label: 'HbA1c', value: '6' },
+        { label: 'Blood Group', value: 'B POSITIVE' },
+      ]);
+    });
+
+    it('should default vitals.additionalMeasurements to empty array', () => {
+      const result = transformVisitSummaryResponse(makeResponse());
+      expect(result.vitals.additionalMeasurements).toEqual([]);
+    });
+  });
+
+  describe('CONCEPT_UUIDS — additional measurements', () => {
+    it('should expose UUIDs for all additional measurement concepts', () => {
+      expect(CONCEPT_UUIDS.FBS).toBeDefined();
+      expect(CONCEPT_UUIDS.PPBS).toBeDefined();
+      expect(CONCEPT_UUIDS.RBS).toBeDefined();
+      expect(CONCEPT_UUIDS.WAIST_CIRCUMFERENCE).toBeDefined();
+      expect(CONCEPT_UUIDS.HIP_CIRCUMFERENCE).toBeDefined();
+      expect(CONCEPT_UUIDS.WAIST_TO_HIP_RATIO).toBeDefined();
+      expect(CONCEPT_UUIDS.OGTT).toBeDefined();
+      expect(CONCEPT_UUIDS.HBA1C).toBeDefined();
+      expect(CONCEPT_UUIDS.BLOOD_GROUP).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
# Pull Request

Display FBS, PPBS, RBS, waist/hip circumference, WHR, OGTT, HbA1c, and
blood group under an "Additional Measurements" subsection in both the
pre-upload (ayu start-visit) and post-upload (server-fetched) visit
summary views, and surface patient name + OpenMRS ID at the top of the
ayu summary page after visit creation.

- Extend Vitals type with optional additionalMeasurements
- Add concept UUIDs and an extractor for the new vitals to the
  visit-summary service transform
- Resolve coded blood group obs via value.display ("B POSITIVE")
- Fetch the patient via patientService.getPatient on the ayu summary
  page, with a storage fallback for name on fetch failure
- Tests bring the three changed files to 100% coverage

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] All pre-commit checks pass

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No console errors or warnings
- [ ] Responsive design tested (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer**: @Zeeshan-IH
**Assignee**: @Zeeshan-IH
