### PR TITLE
@

### DIFF
--- a/src/modules/ayu/pages/visit-summary.page.tsx
+++ b/src/modules/ayu/pages/visit-summary.page.tsx
@@ -24,11 +24,11 @@ import { ConfirmationModal } from '../../../components/modal/confirmation.modal'
 import type { ModalSectionItem } from '../../../components/modal/global-modal-context';
 import { useProfileContext } from '../../../context/ProfileContext';
 import { useConfig } from '../../../hooks/useConfig';
-import { showToast } from '../../../services/toast';
 import { fetchConceptAnswers } from '../../../services/concept.service';
+import { showToast } from '../../../services/toast';
 import type { ConceptAnswer } from '../../../types/config.types';
-import { patientService } from '../../patient/add/add-patient.service';
 import { storage } from '../../../utils/storage';
+import { patientService } from '../../patient/add/add-patient.service';
 import CollapsedComponent from '../../visit-summary/visit-summary-collapsed.component';
 import { ENCOUNTER_TYPES } from '../constants/visit-upload.constants';
 import type { MedicalHistorySummary } from '../context/start-visit.context';
@@ -39,7 +39,9 @@ import {
   clearPendingDocuments,
   getLatestEncounterUuid,
   getLatestVisitUuid,
+  getPendingImages,
   uploadAllAdditionalDocuments,
+  uploadAllPhysicalExamImages,
 } from '../services/obs.service';
 import { bulkMarkSynced } from '../services/temp-storage.service';
 import {
@@ -61,10 +63,8 @@ import {
   PATIENT_NAME_KEY,
   PATIENT_UUID_KEY,
 } from '../utils/ayu.constants';
-import {
-  parseFhirPhysExamQuestionnaire,
-  type FhirQuestionnaire,
-} from '../utils/parseFhirPhysExamQuestionnaire';
+import { transformFhirPhysExamToAyu } from '../../ayu-library/utils/fhir-to-ayu.util';
+import { flattenAyuPhysExamQuestions } from '../utils/physical-exam.utils';
 
 const PRIMARY_COLOR = '#0fd197';
 
@@ -244,7 +244,7 @@ const CheckupReasonSection: React.FC<{ checkupReason: CheckupReason }> = ({
       {checkupReason.chiefComplaints.map(complaint => (
         <span
           key={complaint}
-          className="inline-flex items-center justify-center min-w-[105px] h-[26px] bg-[#2E1E91] text-white text-xs font-semibold rounded-[4px] mr-2 gap-1 py-1 px-2 whitespace-nowrap"
+          className="inline-flex items-center justify-center min-w-26.25 h-6.5 bg-[#2E1E91] text-white text-xs font-semibold rounded-sm mr-2 gap-1 py-1 px-2 whitespace-nowrap"
         >
           {complaint}
         </span>
@@ -315,11 +315,15 @@ const VisitSummaryPage = () => {
   const ayuList = useAyuJsonList(AYU_JSON_KEY_NAME);
   const physicalExamQuestions = useMemo(() => {
     const item = ayuList.find(i => i.name === 'physExam.json');
-    return item
-      ? parseFhirPhysExamQuestionnaire(
-          item.json as unknown as FhirQuestionnaire
-        )
-      : [];
+    if (!item) return [];
+    // Build the obs questions from the SAME transform the PE stepper uses, so
+    // the question ids / option codes line up with the stored answers. Using a
+    // separate parser here left the upload obs blank once the stepper started
+    // unwrapping concept-tag wrappers and collapsing branching sub-forms.
+    const root = transformFhirPhysExamToAyu(
+      item.json as unknown as Parameters<typeof transformFhirPhysExamToAyu>[0]
+    );
+    return flattenAyuPhysExamQuestions(root);
   }, [ayuList]);
   const [allOpen, setAllOpen] = useState(true);
   const [isUploading, setIsUploading] = useState(false);
@@ -477,7 +481,9 @@ const VisitSummaryPage = () => {
       });
 
       const response = await uploadVisit(payload);
-      if (additionalDocuments.length > 0) {
+
+      const hasPendingImages = getPendingImages().length > 0;
+      if (hasPendingImages || additionalDocuments.length > 0) {
         let encounterUuid: string | undefined;
 
         if (response?.encounters) {
@@ -494,11 +500,22 @@ const VisitSummaryPage = () => {
           );
         }
 
-        clearPendingDocuments();
-        for (const doc of additionalDocuments) {
-          addPendingDocument(doc.file, doc.name);
+        if (hasPendingImages && encounterUuid) {
+          try {
+            await uploadAllPhysicalExamImages(encounterUuid, patientUuid);
+          } catch (imgError) {
+            // Visit is already uploaded — don't fail the whole flow on image error
+            console.error('Failed to upload physical exam images:', imgError);
+          }
         }
-        await uploadAllAdditionalDocuments(encounterUuid, patientUuid);
+
+        if (additionalDocuments.length > 0) {
+          clearPendingDocuments();
+          for (const doc of additionalDocuments) {
+            addPendingDocument(doc.file, doc.name);
+          }
+          await uploadAllAdditionalDocuments(encounterUuid, patientUuid);
+        }
       }
 
       if (tempRecordId) {
@@ -522,7 +539,6 @@ const VisitSummaryPage = () => {
   }, [
     data,
     hwProfile,
-    navigate,
     ctxPatientUuid,
     speciality,
     priorityVisit,

--- a/src/modules/ayu/services/visit-upload.service.ts
+++ b/src/modules/ayu/services/visit-upload.service.ts
@@ -1,7 +1,7 @@
 import type { ModalSectionItem } from '../../../components/modal/global-modal-context';
 import { EmrMiddlewareApi } from '../../../services/patient.service';
 import type { MedicalHistorySummary } from '../context/start-visit.context';
-import { ITEM_TYPES } from '../utils/ayu.constants';
+import { ITEM_TYPES, PE_PICTURE_TAKEN_LABEL } from '../utils/ayu.constants';
 import {
   ADULT_INITIAL_CONCEPTS,
   ENCOUNTER_ROLE,
@@ -11,6 +11,7 @@ import {
 } from '../constants/visit-upload.constants';
 import type {
   PhysicalExamAnswers,
+  PhysicalExamOption,
   PhysicalExamQuestion,
 } from '../types/physical-exam.types';
 import type {
@@ -82,15 +83,26 @@ export function buildPhysicalExamData(
   let rawHtml = '';
   let currentSection = '';
 
+  const pictureTag = `[${PE_PICTURE_TAKEN_LABEL}]`;
+
   for (const question of questions) {
     const selectedIds = answers[question.id] ?? [];
     if (selectedIds.length === 0) continue;
 
-    const selectedTexts = selectedIds
-      .map(id => question.options.find(o => o.id === id)?.text)
-      .filter(Boolean);
+    const selectedOptions = selectedIds
+      .map(id => question.options.find(o => o.id === id))
+      .filter((o): o is PhysicalExamOption => Boolean(o));
 
-    if (!selectedTexts.length) continue;
+    // "Picture Taken" is an annotation on the finding, not an answer of its
+    // own — e.g. selecting "Yes" + capturing a photo reads "yes [Picture
+    // Taken]" rather than listing "picture taken" as a separate answer.
+    const answerTexts = selectedOptions
+      .filter(o => !o.isCamera)
+      .map(o => o.text)
+      .filter(Boolean);
+    const hasPicture = selectedOptions.some(o => o.isCamera);
+
+    if (answerTexts.length === 0 && !hasPicture) continue;
 
     if (question.sectionLabel && question.sectionLabel !== currentSection) {
       currentSection = question.sectionLabel;
@@ -99,12 +111,22 @@ export function buildPhysicalExamData(
       rawHtml += `►<b>${sectionName}: </b><br/>`;
     }
 
-    const answerText = selectedTexts.join(', ').toLowerCase();
+    const baseText = answerTexts.join(', ').toLowerCase();
+    const answerText = hasPicture
+      ? `${baseText ? `${baseText} ` : ''}${pictureTag}`
+      : baseText;
     displayHtml += `• ${question.categoryLabel}-${answerText}. <br/>`;
 
     rawHtml += `• ${question.categoryLabel}-● ${question.questionText}${question.isRequired ? '*' : ''}<br/>`;
-    for (const text of selectedTexts) {
-      rawHtml += `•${text}-<br/>`;
+    if (answerTexts.length === 0) {
+      // Picture-only finding.
+      rawHtml += `•${pictureTag}-<br/>`;
+    } else {
+      answerTexts.forEach((text, idx) => {
+        const isLast = idx === answerTexts.length - 1;
+        const suffix = hasPicture && isLast ? ` ${pictureTag}` : '';
+        rawHtml += `•${text}${suffix}-<br/>`;
+      });
     }
   }
 

--- a/src/modules/ayu/utils/physical-exam.utils.ts
+++ b/src/modules/ayu/utils/physical-exam.utils.ts
@@ -1,9 +1,15 @@
 import type { AyuQuestion } from '../../ayu-library/types/ayu.types';
 import {
+  EXT_URL_PE_CATEGORY_LABEL,
+  EXT_URL_PE_OPTION_KIND,
   EXT_URL_PE_QUESTION_KEY,
   EXT_URL_PE_SECTION_KEY,
+  PE_OPTION_KIND_CAMERA,
 } from '../../ayu-library/utils/constants';
-import type { PhysicalExamQuestion } from '../types/physical-exam.types';
+import type {
+  PhysicalExamOption,
+  PhysicalExamQuestion,
+} from '../types/physical-exam.types';
 
 /** Section that is always shown regardless of the protocol filter. */
 export const ALWAYS_INCLUDED_SECTION_KEY = 'General Exams';
@@ -81,4 +87,70 @@ export const filterAyuQuestionsForPhysExam = (
     const questionKey = readExt(q, EXT_URL_PE_QUESTION_KEY);
     return !!questionKey && allowedQuestions.includes(questionKey);
   });
+};
+
+const readQExt = (q: AyuQuestion, url: string): string | undefined =>
+  q.extension?.find(e => e.url === url)?.valueString;
+
+const ayuQuestionToLegacy = (q: AyuQuestion): PhysicalExamQuestion | null => {
+  if (q.type !== 'choice') return null;
+
+  const sectionKey = readQExt(q, EXT_URL_PE_SECTION_KEY) ?? '';
+  const categoryLabel = readQExt(q, EXT_URL_PE_CATEGORY_LABEL) ?? q.text ?? '';
+  const questionKey = readQExt(q, EXT_URL_PE_QUESTION_KEY);
+
+  const options: PhysicalExamOption[] = [];
+  for (const o of q.answerOption ?? []) {
+    const id = o.valueCoding?.code ?? o.valueString;
+    if (!id) continue;
+    const isCamera = o.extension?.some(
+      e =>
+        e.url === EXT_URL_PE_OPTION_KIND &&
+        e.valueString === PE_OPTION_KIND_CAMERA
+    );
+    options.push({
+      id,
+      text: o.valueCoding?.display ?? o.valueString ?? '',
+      ...(isCamera ? { isCamera: true } : {}),
+    });
+  }
+
+  return {
+    id: q.linkId,
+    sectionLabel: sectionKey ? `${sectionKey}:` : '',
+    categoryLabel,
+    questionText: q.text ?? '',
+    isRequired: q.required === true,
+    isMultiChoice: q.repeats === true,
+    options,
+    sectionKey,
+    ...(questionKey !== undefined ? { questionKey } : {}),
+  };
+};
+
+/**
+ * Flatten the AyuQuestion tree produced by transformFhirPhysExamToAyu into the
+ * legacy PhysicalExamQuestion[] shape consumed by buildPhysicalExamData.
+ *
+ * The visit-upload obs HTML must be built from the SAME question IDs / option
+ * codes the stepper stored answers under. The stepper unwraps concept-tag
+ * wrappers and collapses branching sub-forms, so re-parsing the raw FHIR with
+ * the old parseFhirPhysExamQuestionnaire produces mismatched linkIds and the
+ * obs comes out blank. Deriving the questions from the same transform keeps
+ * them aligned. Branching follow-ups are nested under their parent question, so
+ * recurse into `item[]` to surface their answers too.
+ */
+export const flattenAyuPhysExamQuestions = (
+  root: AyuQuestion | null
+): PhysicalExamQuestion[] => {
+  const out: PhysicalExamQuestion[] = [];
+  const walk = (items: AyuQuestion[] | undefined) => {
+    for (const q of items ?? []) {
+      const legacy = ayuQuestionToLegacy(q);
+      if (legacy) out.push(legacy);
+      if (q.item?.length) walk(q.item);
+    }
+  };
+  walk(root?.item);
+  return out;
 };

--- a/src/test/modules/ayu/pages/visit-summary.page.test.tsx
+++ b/src/test/modules/ayu/pages/visit-summary.page.test.tsx
@@ -153,6 +153,8 @@ vi.mock('../../../../services/concept.service', () => ({
 /* ── Mock obs.service ──────────────────────────────────────────────────── */
 
 const mockUploadAllAdditionalDocuments = vi.fn().mockResolvedValue(undefined);
+const mockUploadAllPhysicalExamImages = vi.fn().mockResolvedValue(undefined);
+const mockGetPendingImages = vi.fn().mockReturnValue([]);
 const mockClearPendingDocuments = vi.fn();
 const mockAddPendingDocument = vi.fn();
 const mockGetLatestEncounterUuid = vi.fn().mockResolvedValue(undefined);
@@ -160,6 +162,8 @@ const mockGetLatestVisitUuid = vi.fn().mockResolvedValue('mock-visit-uuid');
 
 vi.mock('../../../../modules/ayu/services/obs.service', () => ({
   uploadAllAdditionalDocuments: (...args: any[]) => mockUploadAllAdditionalDocuments(...args),
+  uploadAllPhysicalExamImages: (...args: any[]) => mockUploadAllPhysicalExamImages(...args),
+  getPendingImages: (...args: any[]) => mockGetPendingImages(...args),
   clearPendingDocuments: (...args: any[]) => mockClearPendingDocuments(...args),
   addPendingDocument: (...args: any[]) => mockAddPendingDocument(...args),
   getLatestEncounterUuid: (...args: any[]) => mockGetLatestEncounterUuid(...args),
@@ -304,6 +308,8 @@ beforeEach(() => {
   mockUploadVisit.mockResolvedValue(undefined);
   mockUseConfig.mockReturnValue({ config: defaultMockConfig });
   mockUploadAllAdditionalDocuments.mockResolvedValue(undefined);
+  mockUploadAllPhysicalExamImages.mockResolvedValue(undefined);
+  mockGetPendingImages.mockReturnValue([]);
   mockGetLatestVisitUuid.mockResolvedValue('mock-visit-uuid');
   mockGetPatient.mockResolvedValue({
     uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
@@ -1513,6 +1519,77 @@ describe('VisitSummaryPage', () => {
     expect(mockClearPendingDocuments).not.toHaveBeenCalled();
     expect(mockAddPendingDocument).not.toHaveBeenCalled();
     expect(mockUploadAllAdditionalDocuments).not.toHaveBeenCalled();
+  });
+
+  it('should upload pending physical exam images after visit upload', async () => {
+    const ADULT_INITIAL_UUID = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f';
+    const imgFile = new File(['pe'], 'pe-image.png', { type: 'image/png' });
+    mockGetPendingImages.mockReturnValue([
+      { file: imgFile, comment: 'General exams' },
+    ]);
+    mockUploadVisit.mockResolvedValue({
+      encounters: [
+        { uuid: 'pe-enc-uuid', encounterType: { uuid: ADULT_INITIAL_UUID } },
+      ],
+    });
+
+    renderWithData(fullData);
+
+    fireEvent.click(screen.getByText('Upload Visit'));
+    fireEvent.click(screen.getByTestId('modal-confirm'));
+
+    await waitFor(() => {
+      expect(mockUploadAllPhysicalExamImages).toHaveBeenCalledWith(
+        'pe-enc-uuid',
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      );
+    });
+  });
+
+  it('should not fail the visit when physical exam image upload throws', async () => {
+    mockGetPendingImages.mockReturnValue([
+      { file: new File(['pe'], 'pe.png', { type: 'image/png' }), comment: 'x' },
+    ]);
+    mockUploadAllPhysicalExamImages.mockRejectedValueOnce(new Error('boom'));
+    mockUploadVisit.mockResolvedValue({
+      encounters: [
+        {
+          uuid: 'pe-enc-uuid',
+          encounterType: { uuid: '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' },
+        },
+      ],
+    });
+
+    renderWithData(fullData);
+
+    fireEvent.click(screen.getByText('Upload Visit'));
+    fireEvent.click(screen.getByTestId('modal-confirm'));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Success',
+        'Visit uploaded successfully',
+        'success'
+      );
+    });
+  });
+
+  it('should not upload physical exam images when there are none pending', async () => {
+    mockGetPendingImages.mockReturnValue([]);
+    renderWithData(fullData);
+
+    fireEvent.click(screen.getByText('Upload Visit'));
+    fireEvent.click(screen.getByTestId('modal-confirm'));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Success',
+        'Visit uploaded successfully',
+        'success'
+      );
+    });
+
+    expect(mockUploadAllPhysicalExamImages).not.toHaveBeenCalled();
   });
 
   it('should render file input with correct accept attribute for images only', () => {

--- a/src/test/modules/ayu/services/visit-upload.service.test.ts
+++ b/src/test/modules/ayu/services/visit-upload.service.test.ts
@@ -212,6 +212,65 @@ describe('visit-upload.service', () => {
       expect(parsed.en).toBe('');
       expect(parsed['l-en']).toBe('');
     });
+
+    it('should annotate the answer with [Picture Taken] when a photo is captured', () => {
+      const questions: PhysicalExamQuestion[] = [
+        makeQuestion({
+          id: 'q1',
+          options: [
+            { id: 'yes', text: 'Yes' },
+            { id: 'no', text: 'No' },
+            { id: 'cam', text: 'Picture Taken', isCamera: true },
+          ],
+        }),
+      ];
+      const answers = { q1: ['yes', 'cam'] };
+
+      const result = buildPhysicalExamData(answers, questions);
+      const parsed = parseObs(result.obsValue);
+
+      // Picture is an annotation on the finding, not a separate answer.
+      expect(parsed.en).toContain('Eyes-yes [Picture Taken].');
+      expect(parsed['l-en']).toContain('•Yes [Picture Taken]-');
+    });
+
+    it('should record a picture-only finding as [Picture Taken]', () => {
+      const questions: PhysicalExamQuestion[] = [
+        makeQuestion({
+          id: 'q1',
+          options: [{ id: 'cam', text: 'Picture Taken', isCamera: true }],
+        }),
+      ];
+      const answers = { q1: ['cam'] };
+
+      const result = buildPhysicalExamData(answers, questions);
+      const parsed = parseObs(result.obsValue);
+
+      expect(parsed.en).toContain('Eyes-[Picture Taken].');
+      expect(parsed['l-en']).toContain('•[Picture Taken]-');
+    });
+
+    it('should append the picture annotation after multiple selected answers', () => {
+      const questions: PhysicalExamQuestion[] = [
+        makeQuestion({
+          id: 'q1',
+          isMultiChoice: true,
+          options: [
+            { id: 'no_jaundice', text: 'No jaundice seen' },
+            { id: 'jaundice', text: 'Jaundice present' },
+            { id: 'cam', text: 'Picture Taken', isCamera: true },
+          ],
+        }),
+      ];
+      const answers = { q1: ['no_jaundice', 'jaundice', 'cam'] };
+
+      const result = buildPhysicalExamData(answers, questions);
+      const parsed = parseObs(result.obsValue);
+
+      expect(parsed.en).toContain(
+        'no jaundice seen, jaundice present [Picture Taken].'
+      );
+    });
   });
 
   // ─── buildMedicalHistoryData ───────────────────────────────────────────────

--- a/src/test/modules/ayu/utils/physical-exam.utils.test.ts
+++ b/src/test/modules/ayu/utils/physical-exam.utils.test.ts
@@ -4,8 +4,18 @@ import type { PhysicalExamQuestion } from '../../../../modules/ayu/types/physica
 import {
   filterAyuQuestionsForPhysExam,
   filterPhysicalExamQuestions,
+  flattenAyuPhysExamQuestions,
   parsePhysicalExamFilter,
 } from '../../../../modules/ayu/utils/physical-exam.utils';
+import {
+  EXT_URL_PE_CATEGORY_LABEL,
+  EXT_URL_PE_OPTION_KIND,
+  EXT_URL_PE_QUESTION_KEY,
+  EXT_URL_PE_SECTION_KEY,
+  PE_OPTION_KIND_CAMERA,
+} from '../../../../modules/ayu-library/utils/constants';
+import { transformFhirPhysExamToAyu } from '../../../../modules/ayu-library/utils/fhir-to-ayu.util';
+import { buildPhysicalExamData } from '../../../../modules/ayu/services/visit-upload.service';
 
 // ── parsePhysicalExamFilter ─────────────────────────────────────────────────
 
@@ -241,5 +251,261 @@ describe('filterAyuQuestionsForPhysExam', () => {
   it('should filter to specific questions within a section', () => {
     const result = filterAyuQuestionsForPhysExam(ayuQuestions, 'Head:Injury');
     expect(result.map(q => q.linkId)).toEqual(['a1', 'a2']);
+  });
+});
+
+// ── flattenAyuPhysExamQuestions ────────────────────────────────────────────
+
+describe('flattenAyuPhysExamQuestions', () => {
+  const peChoice = (
+    linkId: string,
+    sectionKey: string,
+    categoryLabel: string,
+    options: Array<{ code: string; display: string; camera?: boolean }>,
+    children?: AyuQuestion[]
+  ): AyuQuestion => ({
+    linkId,
+    type: 'choice',
+    text: categoryLabel,
+    extension: [
+      { url: EXT_URL_PE_SECTION_KEY, valueString: sectionKey },
+      { url: EXT_URL_PE_CATEGORY_LABEL, valueString: categoryLabel },
+    ],
+    answerOption: options.map(o => ({
+      valueCoding: { code: o.code, display: o.display },
+      ...(o.camera
+        ? {
+            extension: [
+              {
+                url: EXT_URL_PE_OPTION_KIND,
+                valueString: PE_OPTION_KIND_CAMERA,
+              },
+            ],
+          }
+        : {}),
+    })),
+    ...(children ? { item: children } : {}),
+  });
+
+  it('returns empty array for null root', () => {
+    expect(flattenAyuPhysExamQuestions(null)).toEqual([]);
+  });
+
+  it('maps an Ayu choice question to the legacy shape with matching ids', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        peChoice('inner-1', 'Eyes', 'Eyes: Jaundice', [
+          { code: 'yes-code', display: 'Yes' },
+          { code: 'no-code', display: 'No' },
+        ]),
+      ],
+    };
+
+    const result = flattenAyuPhysExamQuestions(root);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'inner-1',
+      sectionKey: 'Eyes',
+      sectionLabel: 'Eyes:',
+      categoryLabel: 'Eyes: Jaundice',
+      options: [
+        { id: 'yes-code', text: 'Yes' },
+        { id: 'no-code', text: 'No' },
+      ],
+    });
+  });
+
+  it('marks camera options with isCamera', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        peChoice('q', 'Skin', 'Skin: Rash', [
+          { code: 'cam', display: 'Picture Taken', camera: true },
+        ]),
+      ],
+    };
+    expect(flattenAyuPhysExamQuestions(root)[0].options[0]).toMatchObject({
+      id: 'cam',
+      isCamera: true,
+    });
+  });
+
+  it('recurses into branching follow-up sub-questions', () => {
+    const followUp = peChoice('sub-1', 'Skin', 'Surface', [
+      { code: 'rough', display: 'Rough' },
+    ]);
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        peChoice(
+          'branch',
+          'Skin',
+          'Is there a rash?',
+          [{ code: 'yes', display: 'Yes' }],
+          [followUp]
+        ),
+      ],
+    };
+    const ids = flattenAyuPhysExamQuestions(root).map(q => q.id);
+    expect(ids).toEqual(['branch', 'sub-1']);
+  });
+
+  // Regression: the upload obs must be built from the same transform the
+  // stepper uses, so a wrapped question's answer is no longer dropped.
+  it('produces non-blank obs end-to-end for a wrapped concept-tag question', () => {
+    const wrapperLinkId = 'ID_wrap';
+    const innerLinkId = 'ID-inner';
+    const questionnaire = {
+      resourceType: 'Questionnaire',
+      item: [
+        {
+          linkId: 'sec-eyes',
+          text: 'Eyes',
+          type: 'group',
+          answerOption: [{ valueCoding: { code: 'tag', display: 'Jaundice' } }],
+          item: [
+            {
+              linkId: wrapperLinkId,
+              text: 'Eyes: Jaundice',
+              type: 'choice',
+              answerOption: [
+                { valueCoding: { code: 'tag', display: 'Is there jaundice?*' } },
+              ],
+              item: [
+                {
+                  linkId: innerLinkId,
+                  text: 'Is there jaundice?*',
+                  type: 'choice',
+                  enableWhen: [
+                    {
+                      question: wrapperLinkId,
+                      operator: '=',
+                      answerCoding: { code: 'tag' },
+                    },
+                  ],
+                  answerOption: [
+                    { valueCoding: { code: 'yes', display: 'Yes' } },
+                    { valueCoding: { code: 'no', display: 'No' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const root = transformFhirPhysExamToAyu(
+      questionnaire as unknown as Parameters<
+        typeof transformFhirPhysExamToAyu
+      >[0]
+    );
+    const questions = flattenAyuPhysExamQuestions(root);
+
+    // The stepper would store the answer under the inner choice's linkId.
+    const answers = { [innerLinkId]: ['yes'] };
+    const { obsValue } = buildPhysicalExamData(answers, questions);
+    const parsed = JSON.parse(obsValue);
+
+    expect(parsed.en).not.toBe('');
+    expect(parsed.en.toLowerCase()).toContain('yes');
+  });
+
+  it('falls back to valueString / code and skips options without an id', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        {
+          linkId: 'q-min',
+          type: 'choice',
+          required: true,
+          repeats: true,
+          // no text, no PE extensions → exercises the empty-string fallbacks
+          answerOption: [
+            { valueString: 'vs-only' }, // id + text from valueString
+            { valueCoding: { code: 'c1' } }, // id from code, text falls back to ''
+            { valueString: '' }, // falsy id → skipped
+            {}, // no id at all → skipped
+          ],
+        },
+      ],
+    };
+
+    const result = flattenAyuPhysExamQuestions(root);
+    expect(result).toHaveLength(1);
+    const q = result[0];
+    expect(q.sectionKey).toBe('');
+    expect(q.sectionLabel).toBe('');
+    expect(q.categoryLabel).toBe('');
+    expect(q.questionText).toBe('');
+    expect(q.isRequired).toBe(true);
+    expect(q.isMultiChoice).toBe(true);
+    expect(q.questionKey).toBeUndefined();
+    expect(q.options).toEqual([
+      { id: 'vs-only', text: 'vs-only' },
+      { id: 'c1', text: '' },
+    ]);
+  });
+
+  it('uses question text as the category label when no category extension', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        {
+          linkId: 'q',
+          type: 'choice',
+          text: 'Free text label',
+          extension: [{ url: EXT_URL_PE_SECTION_KEY, valueString: 'Skin' }],
+          answerOption: [{ valueCoding: { code: 'a', display: 'A' } }],
+        },
+      ],
+    };
+
+    const q = flattenAyuPhysExamQuestions(root)[0];
+    expect(q.categoryLabel).toBe('Free text label');
+    expect(q.questionText).toBe('Free text label');
+    expect(q.sectionLabel).toBe('Skin:');
+  });
+
+  it('skips non-choice items and preserves the question key', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [
+        { linkId: 'note', type: 'string', text: 'A note' }, // non-choice → skipped
+        {
+          linkId: 'q',
+          type: 'choice',
+          text: 'Q',
+          extension: [
+            { url: EXT_URL_PE_SECTION_KEY, valueString: 'Eyes' },
+            { url: EXT_URL_PE_QUESTION_KEY, valueString: 'Jaundice' },
+          ],
+          answerOption: [{ valueCoding: { code: 'y', display: 'Yes' } }],
+        },
+      ],
+    };
+
+    const result = flattenAyuPhysExamQuestions(root);
+    expect(result.map(r => r.id)).toEqual(['q']);
+    expect(result[0].questionKey).toBe('Jaundice');
+  });
+
+  it('yields empty options for a choice question with no answerOption', () => {
+    const root: AyuQuestion = {
+      linkId: 'root',
+      type: 'group',
+      item: [{ linkId: 'q', type: 'choice', text: 'Q' }],
+    };
+
+    const result = flattenAyuPhysExamQuestions(root);
+    expect(result).toHaveLength(1);
+    expect(result[0].options).toEqual([]);
   });
 });


### PR DESCRIPTION
fix(ayu): upload physical-exam photos and align obs with stepper answers

Three related physical-exam fixes in the visit-upload flow:

- Upload pending PE camera images right after the visit upload API call. uploadAllPhysicalExamImages existed and was unit-tested but was never invoked, so captured photos sat in the pending queue and never reached OpenMRS. Resolve the ADULT_INITIAL encounter and flush them (guarded so an image failure cannot roll back the already-uploaded visit).

- Build the obs questions from the same transformFhirPhysExamToAyu the PE stepper uses (via new flattenAyuPhysExamQuestions) instead of the divergent parseFhirPhysExamQuestionnaire. Once the stepper began unwrapping concept-tag wrappers and collapsing branching sub-forms, the upload parser kept the outer wrapper linkIds/codes, so buildPhysicalExamData matched nothing and the physical-exam obs uploaded blank. Deriving questions from the same transform keeps ids/codes aligned with the stored answers.

- Render a captured photo as an annotation on the finding rather than a standalone answer: "yes [Picture Taken]" instead of "yes, picture taken" (and "[Picture Taken]" for a picture-only finding).

Tests added/updated; 100% coverage on the three changed source files.


@

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] All pre-commit checks pass

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No console errors or warnings
- [ ] Responsive design tested (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer**: @Zeeshan-IH
**Assignee**: @Zeeshan-IH
