### PR TITLE
fix(ayu): let physical-exam Yes/No compose with Take a Picture

### DIFF
--- a/src/modules/ayu/components/common/ayu-physical-exam-options.component.tsx
+++ b/src/modules/ayu/components/common/ayu-physical-exam-options.component.tsx
@@ -28,14 +28,19 @@ import { AyuSelectableOption } from './ayu-selectable-option.component';
  * transformFhirPhysExamToAyu attaches; otherwise inert.
  *
  * UX contract:
- *  - Non-camera options commit to answers immediately on click (single-choice
- *    auto-advances via useFHIRStepper).
- *  - Camera tile selection is held in LOCAL state until the user clicks the
- *    Submit/Upload button. This prevents the stepper's auto-advance from
- *    firing before the user has had a chance to actually capture an image.
+ *  - "Take a Picture" composes with the Yes/No answer rather than replacing it —
+ *    the mobile flow lets the user record a finding (Yes/No) AND attach a photo.
+ *    Downstream (buildPhysicalExamData) renders the pair as e.g. "yes [Picture
+ *    Taken]", so the committed answer holds both codes (e.g. ['yes', 'cam']).
+ *  - When the camera tile is NOT in play, a non-camera option commits
+ *    immediately on click (single-choice auto-advances via useFHIRStepper).
+ *  - While the camera tile IS selected, the Yes/No choice is held in LOCAL
+ *    state (pendingRegular) and committed together with the picture on Upload.
+ *    This keeps the stepper from auto-advancing before the user has captured an
+ *    image, and lets Yes/No + picture be chosen together.
  *  - Submit/Upload button visibility:
- *      * multi-choice with any selected option, OR
- *      * camera tile locally selected with at least one image captured.
+ *      * camera tile selected (locally this session OR already committed), with
+ *        the committed Yes/No (if any) preserved on submit.
  */
 export const AyuPhysicalExamOptions = ({
   question,
@@ -44,6 +49,10 @@ export const AyuPhysicalExamOptions = ({
 }: AyuRendererBaseProps) => {
   const camera = usePhysicalExamCamera();
   const [cameraLocallySelected, setCameraLocallySelected] = useState(false);
+  /* Yes/No chosen while the camera tile is active, not yet committed. Held
+   * locally so picking it doesn't auto-advance before the picture is captured;
+   * flushed into the answer (alongside the camera code) on Upload. */
+  const [pendingRegular, setPendingRegular] = useState<string | null>(null);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const [showUploadError, setShowUploadError] = useState(false);
 
@@ -72,6 +81,17 @@ export const AyuPhysicalExamOptions = ({
   const cameraCommitted = !!cameraCode && selected.includes(cameraCode);
   const isCameraSelected = cameraLocallySelected || cameraCommitted;
 
+  /* Non-camera (Yes/No) codes currently committed in the answer. */
+  const committedRegular = selected.filter(id => id !== cameraCode);
+
+  /* Yes/No selection to render. While the camera tile is in use we surface the
+   * uncommitted local choice (pendingRegular) so the tile selection and the
+   * Yes/No selection can be made together before a single Upload commit. */
+  const regularSelected: string[] =
+    !isMultiChoice && pendingRegular !== null
+      ? [pendingRegular]
+      : committedRegular;
+
   const categoryLabel = question.extension?.find(
     e => e.url === EXT_URL_PE_CATEGORY_LABEL
   )?.valueString;
@@ -95,6 +115,11 @@ export const AyuPhysicalExamOptions = ({
       const next =
         without.length === selected.length ? [...selected, optionId] : without;
       setAnswer?.(question, next);
+    } else if (isCameraSelected) {
+      // Camera is in play: hold the Yes/No locally (toggle off on re-click) and
+      // commit it together with the picture on Upload, so selecting Yes/No here
+      // doesn't drop the picture or trigger the stepper's auto-advance.
+      setPendingRegular(prev => (prev === optionId ? null : optionId));
     } else {
       setAnswer?.(question, optionId);
     }
@@ -104,15 +129,17 @@ export const AyuPhysicalExamOptions = ({
     /* The tile is rendered only when both cameraOption and cameraCode are
      * present, so this handler always runs with cameraCode set. */
     if (isCameraSelected) {
-      // Deselecting — drop any in-progress images, clear local state, and
-      // remove a previously committed camera answer (edit case).
+      // Deselecting — drop any in-progress images and the pending Yes/No, clear
+      // local state, and strip only the camera code from a committed answer
+      // (edit case), keeping any committed Yes/No selection intact.
       camera?.clearCameraImages(question.linkId);
       setCameraLocallySelected(false);
+      setPendingRegular(null);
       setShowUploadError(false);
       if (cameraCommitted) {
         setAnswer?.(
           question,
-          isMultiChoice ? selected.filter(id => id !== cameraCode) : ''
+          isMultiChoice ? committedRegular : (committedRegular[0] ?? '')
         );
       }
       return;
@@ -127,10 +154,15 @@ export const AyuPhysicalExamOptions = ({
       return;
     }
     setShowUploadError(false);
-    const next = isMultiChoice
-      ? [...selected.filter(id => id !== cameraCode), cameraCode!]
-      : [cameraCode!];
+    // Commit the Yes/No selection (committed or the pending local choice)
+    // together with the camera code, so a captured picture composes with the
+    // finding instead of replacing it.
+    const next = [
+      ...regularSelected.filter(id => id !== cameraCode),
+      cameraCode!,
+    ];
     setAnswer?.(question, next);
+    setPendingRegular(null);
     setSubmittedAt(Date.now());
   };
 
@@ -196,7 +228,7 @@ export const AyuPhysicalExamOptions = ({
               key={optId}
               label={opt.valueCoding?.display ?? opt.valueString ?? optId}
               value={optId}
-              selected={selected.includes(optId)}
+              selected={regularSelected.includes(optId)}
               leftIcon={getOptionIcon(
                 opt.valueCoding?.display ?? opt.valueString ?? ''
               )}

--- a/src/test/modules/ayu/components/common/ayu-physical-exam-options.component.test.tsx
+++ b/src/test/modules/ayu/components/common/ayu-physical-exam-options.component.test.tsx
@@ -702,6 +702,96 @@ describe('AyuPhysicalExamOptions', () => {
       expect(setAnswer).toHaveBeenCalledWith(question, ['cam']);
     });
 
+    it('lets a single-choice Yes/No be selected together with the camera tile and commits both on Submit', async () => {
+      // Mobile parity: "Take a Picture" composes with the Yes/No finding instead
+      // of replacing it. Selecting the camera tile first, then Yes, must keep
+      // both highlighted and commit ['yes', 'cam'] on Upload.
+      cameraState.imagesByQ['inner-jaundice'] = ['img-1'];
+      const setAnswer = vi.fn();
+      const question = makePeQuestion();
+      render(
+        <AyuPhysicalExamOptions
+          question={question}
+          value={undefined}
+          setAnswer={setAnswer}
+        />
+      );
+      const camTile = screen.getByRole('button', { name: /Take a Picture/ });
+      await userEvent.click(camTile);
+      const yes = screen.getByRole('button', { name: /^Yes$/ });
+      await userEvent.click(yes);
+      // Both highlighted; picking Yes does NOT commit yet (no auto-advance).
+      expect(camTile).toHaveClass('selected');
+      expect(yes).toHaveClass('selected');
+      expect(setAnswer).not.toHaveBeenCalled();
+      // Upload commits the pair.
+      await userEvent.click(
+        screen.getByRole('button', { name: /Upload \(1\)/ })
+      );
+      expect(setAnswer).toHaveBeenCalledWith(question, ['yes', 'cam']);
+    });
+
+    it('toggles off the pending Yes/No when re-clicked while the camera is active', async () => {
+      cameraState.imagesByQ['inner-jaundice'] = ['img-1'];
+      const setAnswer = vi.fn();
+      const question = makePeQuestion();
+      render(
+        <AyuPhysicalExamOptions
+          question={question}
+          value={undefined}
+          setAnswer={setAnswer}
+        />
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /Take a Picture/ })
+      );
+      const yes = screen.getByRole('button', { name: /^Yes$/ });
+      await userEvent.click(yes);
+      expect(yes).toHaveClass('selected');
+      await userEvent.click(yes);
+      expect(yes).not.toHaveClass('selected');
+      await userEvent.click(
+        screen.getByRole('button', { name: /Upload \(1\)/ })
+      );
+      // Yes was toggled off → camera-only answer.
+      expect(setAnswer).toHaveBeenCalledWith(question, ['cam']);
+    });
+
+    it('keeps a committed Yes/No when deselecting an already-committed camera tile', async () => {
+      // value holds both the finding and the picture marker (edit/revisit).
+      cameraState.imagesByQ['inner-jaundice'] = ['img-1'];
+      const setAnswer = vi.fn();
+      const question = makePeQuestion();
+      render(
+        <AyuPhysicalExamOptions
+          question={question}
+          value={['yes', 'cam']}
+          setAnswer={setAnswer}
+        />
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /Take a Picture/ })
+      );
+      // Only the camera marker is stripped; the Yes finding survives.
+      expect(setAnswer).toHaveBeenCalledWith(question, 'yes');
+    });
+
+    it('pre-selects both the Yes finding and the camera tile from a composed answer', () => {
+      render(
+        <AyuPhysicalExamOptions
+          question={makePeQuestion()}
+          value={['yes', 'cam']}
+          setAnswer={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('button', { name: /^Yes$/ })).toHaveClass(
+        'selected'
+      );
+      expect(
+        screen.getByRole('button', { name: /Take a Picture/ })
+      ).toHaveClass('selected');
+    });
+
     it('appends the camera code to existing selections for multi-choice on Submit', async () => {
       cameraState.imagesByQ['inner-jaundice'] = ['img-1'];
       const setAnswer = vi.fn();


### PR DESCRIPTION
Selecting "Take a Picture" no longer replaces the Yes/No finding. While the camera tile is active the Yes/No choice is held locally and committed together with the photo on Upload (e.g. ['yes','cam']), matching the mobile flow and the existing "yes [Picture Taken]" upload format.

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] All pre-commit checks pass

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] No console errors or warnings
- [ ] Responsive design tested (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer**: @Zeeshan-IH
**Assignee**: @Zeeshan-IH
