### PR TITLE
add rule-based AI PR review agent

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -1,0 +1,126 @@
+# PR review agent
+
+An automated reviewer that applies a written rulebook to pull requests and blocks the
+merge while it has findings against one.
+
+**Purely rule-based.** One file — `review-rules.md` — is the entire configuration. No
+generated companion file, no learned weights, no sync step.
+
+Setup, known limits and prioritised improvements are kept in the maintainer handoff,
+outside this repo. Ask the owner (**@Zeeshan-IH**) if you need it.
+
+## When it runs
+
+The model runs only when somebody asks, by adding the **`review-again`** label. Opening a
+PR or pushing to one costs nothing.
+
+The check still reports on every `pull_request` event, because it is a required check and
+one that never reports leaves a PR unmergeable forever:
+
+| Event                              | Check                         | Requests |
+| ---------------------------------- | ----------------------------- | -------- |
+| PR opened / reopened / ready       | 🔴 review not requested       | 0        |
+| Push to an open PR                 | 🔴 code changed               | 0        |
+| `review-again` label               | 🔴 on findings, 🟢 when clean | ≤ 4      |
+| Draft, or a PR into another branch | 🟢 not gated                  | 0        |
+
+A push always sends the check back to red: a review that passed against code you have
+since changed must not keep the merge unblocked.
+
+## How it works
+
+1. **Prepare** — the workflow diffs against the merge base into `.claude-review/pr.diff`,
+   excluding lockfiles, snapshots and build output.
+2. **Review** — `scripts/review.mjs` sends the diff plus a one-line-per-rule digest of
+   `review-rules.md` to an OpenRouter model, and writes `.claude-review/findings.json`.
+3. **Post** — `scripts/post-review.mjs` validates the findings, applies the gate, maps
+   them onto lines GitHub will accept, posts one review, and sets the exit code.
+
+The split between 2 and 3 is the design: **the model decides what is wrong, the script
+decides what gets said.** The confidence floor and the comment cap are code, not requests
+in a prompt.
+
+Step 2 is the only provider-specific part. Anything that writes `findings.json` in the
+documented schema works — swapping providers touches nothing else.
+
+## Rule categories
+
+Every rule ID is `PREFIX-NNN`, where the prefix is its section in `review-rules.md`:
+
+| Prefix  | Covers                                             |
+| ------- | -------------------------------------------------- |
+| `SEC`   | Security                                           |
+| `PHI`   | Patient and personal data                          |
+| `DATA`  | Databases, ORMs, migrations                        |
+| `API`   | Interfaces and contracts                           |
+| `ASYNC` | Async, errors, and control flow                    |
+| `RT`    | Realtime: Socket.IO and WebRTC                     |
+| `FE`    | Frontend: React, Angular, Vue, Ionic, React Native |
+| `TS`    | TypeScript and code health                         |
+| `TEST`  | Tests                                              |
+| `OPS`   | Configuration, deployment, observability           |
+| `STD`   | Project standards from the README                  |
+| `GEN`   | Uncategorised                                      |
+
+`PHI` is the healthcare-specific one — Protected Health Information, though the section
+also covers ordinary personal data like phone numbers and addresses.
+
+**These are not fixed.** The parser requires only `^[A-Z][A-Z0-9]*-\d+$`. To add a
+category, write a `## PERF — Performance` heading and its rules. Nothing else to run.
+
+## Adding a rule
+
+Edit `review-rules.md`. One bold lead-in plus prose:
+
+```markdown
+**FE-008 · minor · Inline styles on a new component.** Style via the project's
+CSS modules instead, so theming stays in one place.
+```
+
+Severity is `blocker | major | minor | nit` and decides what survives the comment cap and
+what the merge gate blocks on. A typo in the severity silently drops the rule — the tests
+assert the shipped rulebook parses, so run them after editing.
+
+## Files
+
+| Path                         | What it is                                             |
+| ---------------------------- | ------------------------------------------------------ |
+| `review-rules.md`            | The rulebook. The only file you edit.                  |
+| `scripts/review.mjs`         | Produces findings via OpenRouter.                      |
+| `scripts/post-review.mjs`    | Gates findings, posts the review, sets the exit code.  |
+| `scripts/lib/rules.mjs`      | Parses the rulebook.                                   |
+| `scripts/lib/gate.mjs`       | Confidence floor, severity floor, dedupe, comment cap. |
+| `scripts/lib/openrouter.mjs` | Model discovery, diff chunking, JSON recovery.         |
+| `scripts/lib/github.mjs`     | Dependency-free GitHub REST client.                    |
+| `findings.schema.json`       | Contract between the model and the posting script.     |
+
+No npm dependencies — they run on the Node 20 already present on `ubuntu-latest`.
+
+## Running the tests
+
+```bash
+node --test .github/review/scripts/test/*.test.mjs
+```
+
+## Deliberate limits
+
+**An unread diff never reads as clean.** An empty findings array means either "the code is
+fine" or "the model gave up", and those are indistinguishable to branch protection. The
+review records whether it actually engaged, and an incomplete review fails the check with
+a different message from "you have findings to fix". The cost is that a provider outage
+holds merges until someone re-requests a review — deliberate, because a silent pass
+leaves no trace of having been skipped.
+
+**It only sees the diff.** One chat completion per batch, no tools, no filesystem. It
+cannot open a config file or grep for a caller, so rules needing repo context miss more
+often. This is the biggest constraint — see the handoff for what would fix it.
+
+**Large diffs cap out** at 4 requests × 40,000 chars. Beyond that, files are dropped and
+the review reports inconclusive. Raise `MAX_REQUESTS` or split the PR.
+
+**Fork PRs are skipped** — GitHub withholds secrets from those runs.
+
+**There is no `/review` comment trigger.** A comment handler can only request a review by
+applying the label, and GitHub does not start workflow runs from events created by
+`GITHUB_TOKEN` — so the label lands and nothing happens. Enabling it needs a PAT or GitHub
+App token; the label needs neither.

--- a/.github/review/findings.schema.json
+++ b/.github/review/findings.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/intelehealth/.github/review/findings.schema.json",
+  "title": "Claude PR review findings",
+  "description": "Structured output the review agent writes to .claude-review/findings.json. post-review.mjs validates against this before anything is posted.",
+  "type": "object",
+  "required": ["summary", "findings"],
+  "additionalProperties": false,
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000,
+      "description": "Plain-English verdict on the PR as a whole."
+    },
+    "findings": {
+      "type": "array",
+      "maxItems": 60,
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "required": [
+        "ruleId",
+        "file",
+        "line",
+        "severity",
+        "confidence",
+        "title",
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "pattern": "^[A-Z]+-[0-9]+$",
+          "description": "Must exist in review-rules.md."
+        },
+        "file": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path exactly as it appears in the diff."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number in the new version of the file."
+        },
+        "endLine": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "End of the range, for multi-line findings. Defaults to line."
+        },
+        "severity": { "enum": ["blocker", "major", "minor", "nit"] },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Honest probability a senior engineer would agree this is real."
+        },
+        "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "body": { "type": "string", "minLength": 1, "maxLength": 4000 },
+        "suggestion": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Exact replacement code for line..endLine. No code fences."
+        }
+      }
+    }
+  }
+}

--- a/.github/review/review-rules.md
+++ b/.github/review/review-rules.md
@@ -406,6 +406,29 @@ agreed to it; absent that, treat it as debugging that was forgotten. In this
 codebase a stray `console.log` on a patient object is also a `PHI-001` — cite
 both when the logged value could carry patient data.
 
+**STD-009 · major · Coverage bypassed with an ignore pragma.** A new
+`/* v8 ignore next */`, `/* c8 ignore next */`, `/* c8 ignore start|stop */`,
+`/* istanbul ignore next|else|file */`, or a per-file `coverage` exclusion added
+to `vitest.config.ts`. The project requires 100% branches, functions, lines and
+statements — a pragma does not meet that bar, it removes the code from the
+measurement, so the number stays at 100% while the code goes untested.
+
+Treat the pragma as the signal that the code is hard to test, and say which of
+these it is:
+
+- **Unreachable by construction** — a `default:` on an exhaustive switch, an
+  `if (!x) throw` after the type system already guarantees `x`. The honest fix
+  is usually to delete the branch, not to hide it.
+- **Hard to reach because of a seam** — an error path behind a real `fetch`, a
+  timer, a browser API. Inject the dependency or use the project's wrapper, and
+  the branch becomes reachable in a test.
+- **Genuinely untestable** — rare. Then the pragma stays, and the PR says in a
+  comment on that line why, so the next reader does not have to re-derive it.
+
+Existing pragmas are out of scope; only flag ones this PR adds. There are
+already ~40 in `src/`, so treat each new one as widening a gap rather than
+following a precedent.
+
 ---
 
 ## GEN — Uncategorised

--- a/.github/review/review-rules.md
+++ b/.github/review/review-rules.md
@@ -1,0 +1,447 @@
+# PR Review Rulebook
+
+This is the instruction set the automated reviewer applies to every pull request,
+and it is the **only** configuration it has. Edit this file and the next review
+uses it — there is no generated companion file and no sync step to run.
+
+Treat it as a living document: when the reviewer misses something a human caught,
+add a rule; when a rule keeps firing on non-issues, reword it or delete it.
+
+## How the reviewer uses this file
+
+Each rule below is sent to the model as one compact line — ID, severity, title.
+The prose under each rule is for you, not the model, so write it for whoever
+edits this file next.
+
+Every finding must cite one of these rule IDs; anything citing an ID that is not
+here is discarded before it reaches the pull request.
+
+Severities:
+
+- **blocker** — would cause data loss, a security hole, a patient-safety issue,
+  or a production outage. Should not merge.
+- **major** — a real bug or a design decision that will be expensive to undo.
+- **minor** — a genuine issue with a bounded cost.
+- **nit** — worth mentioning, never worth blocking on.
+
+The bot is instructed to stay silent below 60% confidence, and to skip anything
+a linter or formatter already enforces. Reviewer attention is the scarce
+resource being protected here, not model tokens.
+
+## Scope
+
+Review only lines the PR adds or modifies. Reading surrounding code for context
+is expected; reporting pre-existing issues in untouched code is not.
+
+**These rules describe the application.** They apply to `src/**` — the React app
+and its tests. They do **not** apply to build and CI tooling: `.github/**`,
+`*.config.ts`, and scripts that run in Actions rather than in the browser.
+
+That distinction is not a loophole, it is what keeps the rules meaningful. A CI
+script's `console.log` is its only output channel, not stray debugging. A Node
+script has no `.component.ts` to be named after and no HTTP wrapper to prefer
+over `fetch`. The 200-line target describes a React component, not a build
+script. Applying `STD` to tooling would produce findings on every workflow file
+in perpetuity, and a reviewer that cries wolf gets ignored — taking the findings
+that mattered with it.
+
+`SEC` and `PHI` are the exception: a committed credential or a leaked patient
+identifier is a defect wherever it appears, tooling included.
+
+---
+
+## SEC — Security
+
+**SEC-001 · blocker · Injection via unparameterised query.** String
+concatenation or template literals building SQL, or user input reaching a Mongo
+query operator position. Sequelize `replacements`/`bind`, or an explicit
+parameterised query, is required. In Mongoose, reject any path where a
+request-supplied object can land where a query operator is expected — that is
+how `$ne`/`$gt` operator injection gets in.
+
+**SEC-002 · blocker · Missing authentication or authorisation on a new route.**
+A new Express route, NestJS controller method, or Socket.IO event handler that
+does not sit behind the project's auth guard/middleware, or that authenticates
+the caller but never checks that the caller is allowed to touch _this_ record.
+Broken object-level authorisation is the most common real vulnerability in this
+kind of codebase; flag it explicitly rather than assuming a guard exists further
+up.
+
+**SEC-003 · blocker · Secret, key, or credential committed.** API keys, tokens,
+private keys, connection strings with embedded passwords, or `.env` files in the
+diff. Applies to test fixtures too.
+
+**SEC-004 · major · Unvalidated request input.** A handler reading `req.body`,
+`req.query`, or `req.params` and using it without schema validation
+(`class-validator` DTO, Joi, Zod, or the project's equivalent). Type assertions
+in TypeScript are not validation — `as CreateUserDto` proves nothing at runtime.
+
+**SEC-005 · major · Mass assignment.** Spreading a request body straight into a
+model create/update (`Model.create({ ...req.body })`, `Object.assign(user,
+req.body)`). Fields like `role`, `isAdmin`, `verified`, or `tenantId` become
+attacker-controlled.
+
+**SEC-006 · major · Unsafe rendering or DOM injection.** `dangerouslySetInnerHTML`,
+Angular `bypassSecurityTrustHtml`, Vue `v-html`, or direct `innerHTML` assignment
+with data that is not provably static or sanitised.
+
+**SEC-007 · major · Weak or hand-rolled cryptography.** MD5/SHA-1 for passwords,
+`Math.random()` for tokens or IDs, custom encryption, or JWTs verified without
+checking the algorithm and expiry.
+
+**SEC-008 · major · Overly permissive CORS or cookie flags.** `origin: '*'`
+alongside credentials, or session cookies missing `httpOnly`, `secure`, or
+`sameSite`.
+
+**SEC-009 · minor · Dependency added with no obvious need.** A new runtime
+dependency in `package.json` that duplicates something already present or that
+is doing work a few lines of code would do. Note it; do not block.
+
+---
+
+## PHI — Patient and personal data
+
+These matter more here than in a typical codebase. Apply them to anything that
+looks like patient identity, clinical notes, visit records, prescriptions,
+diagnoses, phone numbers, or location.
+
+**PHI-001 · blocker · Patient-identifying data in logs.** `console.log`,
+logger calls, or error messages that include a patient name, identifier,
+phone number, address, or clinical detail. Log an opaque ID instead.
+
+**PHI-002 · blocker · Patient data sent to a third party.** New calls to an
+analytics, monitoring, crash-reporting, or AI service whose payload could carry
+PHI. Includes Sentry `extra`/`context` and analytics event properties.
+
+**PHI-003 · major · Patient data in client-side storage.** `localStorage`,
+`sessionStorage`, IndexedDB, or `AsyncStorage` holding clinical or identifying
+data without a clear, deliberate reason and a cleanup path on logout.
+
+**PHI-004 · major · Over-broad response payload.** An endpoint returning a whole
+patient or user document where the caller needs a few fields. Call out the
+specific fields that should not be crossing the wire.
+
+**PHI-005 · minor · Missing audit trail on a sensitive action.** Create, update,
+export, or delete of clinical records without a corresponding audit log entry,
+where the codebase has an audit mechanism.
+
+---
+
+## DATA — Databases, ORMs, migrations
+
+**DATA-001 · blocker · Destructive or irreversible migration.** A migration that
+drops a column or table, or changes a type in a way that loses data, without a
+documented backfill and rollback path. Also flag migrations with no `down`.
+
+**DATA-002 · blocker · Multi-step write with no transaction.** Two or more
+related writes that must succeed or fail together, issued without a Sequelize
+transaction or a Mongo session. Partial writes here mean corrupted clinical
+records.
+
+**DATA-003 · major · N+1 query.** A query inside a loop or `.map()` over a
+result set. In Sequelize, prefer `include`; in Mongoose, prefer `populate` or a
+single `$in` query.
+
+**DATA-004 · major · Unbounded query.** `findAll` / `find({})` with no `limit`,
+no pagination, and no obvious bound on row count. It works on a dev database and
+falls over on a real one.
+
+**DATA-005 · major · New query pattern with no supporting index.** A filter or
+sort on fields that are unlikely to be indexed, with no accompanying migration
+or schema index. Say which index you would add.
+
+**DATA-006 · minor · Schema change without a corresponding migration.** A model
+or entity definition changed with nothing in the migrations directory.
+
+**DATA-007 · minor · Connection or session not released.** A transaction,
+session, or connection acquired without a `finally` that releases it on the
+error path.
+
+---
+
+## API — Interfaces and contracts
+
+**API-001 · major · Breaking change to a published contract.** A removed or
+renamed field, a changed type, a narrowed enum, or a newly required request
+field on an endpoint or event that clients already use — with no versioning and
+no deprecation path. Mobile clients in particular cannot be upgraded in lockstep.
+
+**API-002 · major · Wrong or misleading status codes.** Errors returned as
+`200`, validation failures as `500`, or a `catch` that swallows everything into
+one generic status.
+
+**API-003 · minor · Inconsistent response shape.** A new endpoint whose success
+or error envelope differs from the pattern the rest of the service uses.
+
+**API-004 · minor · Undocumented endpoint.** A new public route with no Swagger/
+OpenAPI decorator or doc entry, in a service that otherwise documents its routes.
+
+---
+
+## ASYNC — Async, errors, and control flow
+
+**ASYNC-001 · blocker · Unhandled promise rejection path.** An `async` function
+called without `await` or `.catch()` where a rejection would be silently lost, or
+an `async` callback passed to an API that ignores the returned promise
+(`setInterval`, `forEach`, Express handlers without an error wrapper).
+
+**ASYNC-002 · major · Swallowed error.** `catch {}`, `catch (e) { console.log(e) }`
+with no rethrow or recovery, or a catch that returns a success value. If the
+error is genuinely expected, that reasoning belongs in a comment.
+
+**ASYNC-003 · major · Awaiting in a loop where the work is independent.**
+Sequential `await` inside a `for` loop over items with no dependency between
+iterations. Use `Promise.all` — bounded with a concurrency limit if the list can
+be large.
+
+**ASYNC-004 · major · Race condition on shared state.** Two async paths reading
+and writing the same in-memory map, cache entry, or record with no locking,
+compare-and-set, or atomic update.
+
+**ASYNC-005 · minor · External call with no timeout or retry policy.** `fetch`,
+`axios`, or a database call to a remote service with no timeout, in code where a
+hang would block a request path.
+
+---
+
+## RT — Realtime: Socket.IO and WebRTC
+
+**RT-001 · blocker · Socket event handler without authentication.** A
+`socket.on(...)` handler that trusts a client-supplied user or room ID instead of
+the identity established at connection time.
+
+**RT-002 · major · Listener registered without cleanup.** `socket.on`,
+`addEventListener`, `RTCPeerConnection` event handlers, or subscriptions added
+with no matching removal on disconnect, unmount, or teardown. This is the usual
+source of a slow memory leak and of handlers firing twice.
+
+**RT-003 · major · Peer connection or media track not closed.** An
+`RTCPeerConnection`, `MediaStream`, or track opened without a path that closes
+it and stops the tracks — including on the error and early-return paths. On
+mobile this leaves the camera light on.
+
+**RT-004 · major · Broadcast to a room without an authorisation check.**
+Emitting to a room derived from user input, or joining a room without verifying
+the user belongs to it.
+
+**RT-005 · minor · No reconnection or degraded-network handling.** New realtime
+code that assumes a stable connection. Relevant for low-bandwidth field use.
+
+---
+
+## FE — Frontend: React, Angular, Vue, Ionic, React Native
+
+**FE-001 · major · Effect with a wrong or missing dependency array.** A
+`useEffect`/`useCallback`/`useMemo` whose dependencies do not match what it
+reads, causing a stale closure or an infinite render loop.
+
+**FE-002 · major · State update after unmount.** An async result written to
+state with no cancellation, `AbortController`, or mounted guard.
+
+**FE-003 · major · Subscription without teardown.** An RxJS subscription in
+Angular with no `takeUntil`/`async` pipe, a Vue watcher never stopped, or a
+React effect that returns no cleanup where it should.
+
+**FE-004 · minor · Expensive work on every render.** Non-trivial computation,
+object/array literals, or new function identities passed as props into memoised
+children, causing avoidable re-renders.
+
+**FE-005 · minor · Unkeyed or index-keyed list.** `key={index}` on a list that
+can reorder, insert, or delete.
+
+**FE-006 · minor · Accessibility gap on a new interactive element.** A clickable
+`div`, a form control with no label, or an icon-only button with no accessible
+name.
+
+**FE-007 · minor · User-facing string hardcoded.** New copy inserted directly
+rather than through the project's i18n mechanism, in a codebase that has one.
+
+---
+
+## TS — TypeScript and code health
+
+**TS-001 · major · `any` or a type assertion hiding a real mismatch.** `any`,
+`as unknown as X`, or a non-null assertion `!` used to silence the compiler
+rather than because the invariant is genuinely known. Say what the correct type
+is.
+
+**TS-002 · major · Missing null/undefined handling.** A value that can be
+`undefined` — an optional field, an array `find`, an env var, a `JSON.parse`
+result — used without a check.
+
+**TS-003 · minor · `@ts-ignore` / `eslint-disable` with no justification.**
+Suppressions are fine when explained; unexplained ones accumulate.
+
+**TS-004 · minor · Dead or unreachable code.** Commented-out blocks, unused
+exports, or branches that cannot be taken, introduced by this PR.
+
+**TS-005 · minor · Duplicated logic.** The same non-trivial logic added in a
+second place where an existing helper would do, or where a helper is now
+warranted.
+
+---
+
+## TEST — Tests
+
+**TEST-001 · major · Bug fix with no regression test.** A PR that fixes
+described broken behaviour without a test that would have caught it.
+
+**TEST-002 · minor · New business logic with no test coverage.** A new service
+method, reducer, or non-trivial pure function with no accompanying test, in a
+repo that has a test suite.
+
+**TEST-003 · minor · Flaky test pattern.** A test depending on wall-clock time,
+network access, a fixed sleep, or execution order.
+
+**TEST-004 · minor · Assertion that cannot fail.** `expect(true).toBe(true)`,
+a snapshot committed without review, or a test with no assertion at all.
+
+---
+
+## OPS — Configuration, deployment, observability
+
+**OPS-001 · major · Configuration hardcoded.** A URL, timeout, feature flag,
+region, or limit written inline where the project uses config or environment
+variables. Especially anything that differs between environments.
+
+**OPS-002 · major · New env var with no default, no validation, and no docs.**
+It will work locally and crash on deploy.
+
+**OPS-003 · minor · Missing observability on a new critical path.** A new
+integration, job, or payment/clinical workflow with no logging or metric at its
+failure points.
+
+**OPS-004 · minor · Backwards-incompatible change with no deploy ordering
+note.** A change that requires the migration, the API, and the client to ship in
+a particular order, with nothing in the PR description saying so.
+
+**OPS-005 · major · Automated safety net removed or weakened.** A CI workflow,
+test, coverage threshold, lint rule, or type check deleted, disabled, or
+loosened, without the PR saying what replaces it. Includes skipping tests
+(`.skip`, `xit`), lowering a coverage floor, adding a broad `eslint-disable` at
+file scope, and removing a required status check. Say which protection is being
+given up and what now catches that class of problem instead. A deliberate
+removal is fine; an unexplained one is how a repo quietly loses its guardrails.
+
+---
+
+## STD — Project standards
+
+These come from the conventions documented in the repository README. They are
+house style rather than defects, so most sit at `minor` — but they are the rules
+that keep a codebase readable as it grows, and a reviewer that ignores them
+leaves the whole category to chance.
+
+**STD-001 · minor · Constant defined outside a constants file.** A literal that
+is configuration rather than a one-off — an endpoint path, a storage key, a
+timeout, a limit, a feature-flag name, a route, an enum-like set of strings —
+declared inline in a component, hook, or service. Move it to the module's
+`*.constant.ts` (e.g. `auth.constant.ts`, `api.constant.ts`) and import it.
+Repeating the same literal in two places is the clearest signal it belongs there.
+
+**STD-002 · minor · Constant not named in PASCAL_SNAKE_CASE.** Exported
+constants are upper-case words joined by underscores: `MAX_RETRY_COUNT`,
+`AUTH_TOKEN_KEY`, `DEFAULT_PAGE_SIZE`. Not `maxRetryCount`, not `MaxRetryCount`,
+not `MAXRETRYCOUNT`. The name must also say what the value _is_ — `TIMEOUT_MS`
+rather than `TIMEOUT`, `PATIENT_LIST_ENDPOINT` rather than `URL2`.
+
+**STD-003 · minor · Uninformative identifier.** A variable, parameter, function,
+or type whose name does not say what it holds or does: `data`, `res`, `temp`,
+`val`, `arr`, `obj`, `flag`, `x`, `handleClick2`, or a name that describes the
+type rather than the meaning (`stringArray` instead of `visitIds`). Loop indices
+and idiomatic short names in a two-line scope are fine. Say what the value means
+in this domain, not what shape it has.
+
+**STD-004 · nit · Single-line comment where a block comment belongs.** Code
+comments use the multi-line form:
+
+```ts
+/**
+ * Explains why, not what.
+ */
+```
+
+Not `// like this`. Applies to comments explaining code; `// eslint-disable`
+directives, `// @ts-expect-error` and similar tooling pragmas are not comments in
+this sense and stay as they are.
+
+**STD-005 · minor · File naming convention not followed.** New files use the
+suffix for their kind: `.component.ts`, `.service.ts`, `.hook.ts`, `.types.ts`,
+`.reducer.ts`, `.util.ts`, `.constant.ts`, `.test.ts`. A service named
+`authHelpers.ts` or a hook named `useAuth.ts` should be `auth.service.ts` and
+`auth.hook.ts`.
+
+**STD-006 · minor · Web API used directly instead of the project's wrapper.**
+`localStorage` / `sessionStorage`, `fetch` / `XMLHttpRequest`, `document.cookie`,
+IndexedDB, `WebSocket`, the File API, Geolocation, and the Notification API all
+have project utilities or services. Call those instead — the wrappers carry the
+auth, error handling, and cleanup that direct calls skip. Name the utility that
+should have been used.
+
+**STD-007 · nit · File is growing past the size limit.** The project targets a
+maximum of 200 lines per file, preferably 150–180, with one responsibility each.
+Flag a file this PR pushes well beyond that, and say which responsibility should
+move out.
+
+**STD-008 · major · Console statement left in the code.** No `console.log` ships.
+Temporary logging for a genuinely hard bug on `dev` is allowed only when it was
+agreed in advance, and it comes out before the PR is reviewed — so by the time
+the reviewer sees it, there should be none.
+
+Flag every one, including the escapes a linter cannot catch:
+
+- a `console.log` behind `// eslint-disable-next-line no-restricted-syntax`
+- `console.debug`, `console.info`, `console.trace`, `console.table`, or
+  `console.dir` — the ESLint rule here only matches `console.log`, so these pass
+  lint and still ship
+- a `console.log` reached through an alias or a wrapper written to dodge the rule
+- logging left behind a `if (import.meta.env.DEV)` guard, unless it is deliberate
+  instrumentation the PR description explains
+
+`console.warn` and `console.error` are permitted for real error paths. Test
+files are exempt — ESLint already turns the rule off there.
+
+If a statement genuinely must stay, the PR description has to say why and who
+agreed to it; absent that, treat it as debugging that was forgotten. In this
+codebase a stray `console.log` on a patient object is also a `PHI-001` — cite
+both when the logged value could carry patient data.
+
+---
+
+## GEN — Uncategorised
+
+**GEN-000 · minor · Issue not covered by an existing rule.** Used when the bot
+believes it has found a real problem that no rule above describes. The finding
+body must propose the rule that would cover it. Review these periodically — a
+GEN-000 that recurs is a rule waiting to be written.
+
+---
+
+## Editing this file
+
+**Adding a rule:** write the entry in the right section. That is the whole
+procedure — nothing to regenerate, nothing to keep in step.
+
+```markdown
+**FE-008 · minor · Inline styles on a new component.** Style via the project's
+CSS modules instead, so theming stays in one place.
+```
+
+The shape is `**ID · severity · Title.** prose`. Severity is one of `blocker`,
+`major`, `minor`, `nit`.
+
+**Removing a rule:** delete it. Findings citing it stop being accepted from the
+next review onward.
+
+**Adding a category:** write a `## PERF — Performance` heading and put rules
+under it. Prefixes are free-form; the parser only requires `PREFIX-NNN`.
+
+Two things that bite:
+
+- **A typo in the severity silently drops the rule.** `critical` is not a
+  severity, so that line is skipped and the rule simply never fires. Run
+  `node --test .github/review/scripts/test/rules.test.mjs` after editing — it
+  asserts this file parses and every rule is usable.
+- **Severity is the lever that matters.** Every rule faces the same confidence
+  floor; severity decides what survives the comment cap and what the merge gate
+  blocks on.

--- a/.github/review/scripts/lib/gate.mjs
+++ b/.github/review/scripts/lib/gate.mjs
@@ -1,0 +1,90 @@
+/**
+ * Decides which findings get posted. Pure functions, no state, no history.
+ *
+ * The model decides what is wrong; this decides what gets said. Keeping the
+ * threshold and the comment cap here as code — rather than as requests in a
+ * prompt — is what makes them actually hold.
+ */
+
+import { SEVERITY_ORDER } from './rules.mjs';
+
+/** Ignore anything the model is not reasonably sure about. */
+export const MIN_CONFIDENCE = 0.6;
+
+/** Never bury a reviewer under one PR's worth of comments. */
+export const MAX_COMMENTS = 12;
+
+/** FNV-1a. Short, stable, and enough to tell two findings apart. */
+export function hash32(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(36);
+}
+
+/**
+ * Stable identifier for a finding, so a re-review does not repost what is
+ * already on the PR. Deliberately excludes confidence and body text: the same
+ * issue on the same line is the same issue even if the wording shifts.
+ */
+export function findingId(f) {
+  return hash32(`${f.ruleId}|${f.file}|${f.line}|${f.severity}`);
+}
+
+/**
+ * Filter findings down to what should be posted.
+ *
+ * @param {Array<object>} findings
+ * @param {{alreadyPosted?:Set<string>, minConfidence?:number,
+ *          minSeverity?:string, maxComments?:number}} opts
+ * @returns {{kept:Array<object>, dropped:Array<{finding:object, reason:string}>}}
+ */
+export function gateFindings(findings, opts = {}) {
+  const {
+    alreadyPosted = new Set(),
+    minConfidence = MIN_CONFIDENCE,
+    minSeverity = 'nit',
+    maxComments = MAX_COMMENTS,
+  } = opts;
+
+  const floor = SEVERITY_ORDER[minSeverity] ?? SEVERITY_ORDER.nit;
+  const kept = [];
+  const dropped = [];
+
+  // Most severe first, then most confident, so the comment cap keeps the
+  // findings that matter rather than whichever the model happened to list.
+  const ordered = [...findings].sort(
+    (a, b) =>
+      SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
+      b.confidence - a.confidence
+  );
+
+  for (const f of ordered) {
+    const fid = findingId(f);
+
+    if (f.confidence < minConfidence) {
+      dropped.push({ finding: f, reason: `confidence ${f.confidence}` });
+      continue;
+    }
+    if (SEVERITY_ORDER[f.severity] > floor) {
+      dropped.push({ finding: f, reason: `below ${minSeverity}` });
+      continue;
+    }
+    if (alreadyPosted.has(fid)) {
+      dropped.push({ finding: f, reason: 'already posted' });
+      continue;
+    }
+    if (kept.length >= maxComments) {
+      dropped.push({
+        finding: f,
+        reason: `over the ${maxComments}-comment cap`,
+      });
+      continue;
+    }
+    kept.push({ ...f, _fid: fid });
+  }
+
+  return { kept, dropped };
+}

--- a/.github/review/scripts/lib/github.mjs
+++ b/.github/review/scripts/lib/github.mjs
@@ -1,0 +1,186 @@
+/**
+ * Minimal GitHub REST + GraphQL client.
+ *
+ * Deliberately dependency-free: these scripts run in CI on every PR, and a
+ * zero-dependency script needs no `npm install` step, has no supply-chain
+ * surface, and cannot break because a transitive dependency shipped a bad
+ * release. Node 20+ has everything required.
+ */
+
+const API = process.env.GITHUB_API_URL || 'https://api.github.com';
+const GRAPHQL =
+  process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
+
+function token() {
+  const t = process.env.GITHUB_TOKEN;
+  if (!t) throw new Error('GITHUB_TOKEN is not set');
+  return t;
+}
+
+function baseHeaders() {
+  return {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token()}`,
+    'x-github-api-version': '2022-11-28',
+    'user-agent': 'claude-pr-review-agent',
+  };
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+/**
+ * REST request with retry on 5xx and secondary-rate-limit responses.
+ * @param {string} path e.g. `/repos/o/r/pulls/1/files`
+ * @param {{method?:string, body?:unknown, retries?:number}} [opts]
+ */
+export async function rest(path, opts = {}) {
+  const { method = 'GET', body, retries = 3 } = opts;
+  const url = path.startsWith('http') ? path : `${API}${path}`;
+
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        ...baseHeaders(),
+        ...(body ? { 'content-type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (res.ok) {
+      const text = await res.text();
+      return {
+        data: text ? JSON.parse(text) : null,
+        link: res.headers.get('link') || '',
+      };
+    }
+
+    const text = await res.text();
+    const retryable =
+      res.status >= 500 ||
+      res.status === 429 ||
+      (res.status === 403 && /rate limit|abuse|secondary/i.test(text));
+
+    lastErr = new Error(
+      `${method} ${url} -> ${res.status}: ${text.slice(0, 600)}`
+    );
+    if (!retryable || attempt === retries) throw lastErr;
+
+    const retryAfter = Number(res.headers.get('retry-after'));
+    await sleep(
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1000
+        : 2 ** attempt * 1000
+    );
+  }
+  throw lastErr;
+}
+
+/** Follow `Link: rel="next"` until exhausted. */
+export async function restAll(path, { max = 1000 } = {}) {
+  const out = [];
+  let url = path.includes('?')
+    ? `${path}&per_page=100`
+    : `${path}?per_page=100`;
+  while (url && out.length < max) {
+    const { data, link } = await rest(url);
+    if (!Array.isArray(data)) break;
+    out.push(...data);
+    const next = /<([^>]+)>;\s*rel="next"/.exec(link);
+    url = next ? next[1] : null;
+  }
+  return out.slice(0, max);
+}
+
+/** GraphQL request. Used only where REST has no equivalent (thread resolution). */
+export async function graphql(query, variables = {}) {
+  const res = await fetch(GRAPHQL, {
+    method: 'POST',
+    headers: { ...baseHeaders(), 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (!res.ok || json.errors) {
+    throw new Error(
+      `GraphQL error: ${JSON.stringify(json.errors || json).slice(0, 600)}`
+    );
+  }
+  return json.data;
+}
+
+/**
+ * Parse a unified diff patch into the set of new-file line numbers that GitHub
+ * will accept a RIGHT-side review comment on.
+ *
+ * This matters: posting a review with a single out-of-diff line makes the
+ * entire review request fail with a 422, losing every other comment with it.
+ * We check up front and demote anything out of range into the summary instead.
+ *
+ * @param {string} patch
+ * @returns {Set<number>}
+ */
+export function commentableLines(patch) {
+  const lines = new Set();
+  if (!patch) return lines;
+
+  let newLine = 0;
+  for (const raw of patch.split('\n')) {
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (raw.startsWith('\\')) continue; // "\ No newline at end of file"
+    if (raw.startsWith('-')) continue; // removed: exists only on the LEFT side
+    if (raw.startsWith('+') || raw.startsWith(' ')) {
+      lines.add(newLine);
+      newLine++;
+    }
+  }
+  return lines;
+}
+
+/** Files touched by a PR, with their patches. */
+export async function getPullFiles(repo, prNumber) {
+  return restAll(`/repos/${repo}/pulls/${prNumber}/files`, { max: 300 });
+}
+
+/** Existing review comments on a PR. */
+export async function getReviewComments(repo, prNumber) {
+  return restAll(`/repos/${repo}/pulls/${prNumber}/comments`, { max: 500 });
+}
+
+/** Reactions on a single PR review comment. */
+export async function getCommentReactions(repo, commentId) {
+  return restAll(`/repos/${repo}/pulls/comments/${commentId}/reactions`, {
+    max: 100,
+  });
+}
+
+/**
+ * Post one review containing all inline comments plus a summary body.
+ * @param {string} repo
+ * @param {number|string} prNumber
+ * @param {{commitId:string, body:string, event:'COMMENT'|'REQUEST_CHANGES', comments:Array<object>}} opts
+ */
+export async function createReview(
+  repo,
+  prNumber,
+  { commitId, body, event, comments }
+) {
+  const { data } = await rest(`/repos/${repo}/pulls/${prNumber}/reviews`, {
+    method: 'POST',
+    body: { commit_id: commitId, body, event, comments },
+  });
+  return data;
+}
+
+/** Post a plain issue comment (used as the fallback when inline posting fails). */
+export async function createIssueComment(repo, prNumber, body) {
+  const { data } = await rest(`/repos/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    body: { body },
+  });
+  return data;
+}

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -1,0 +1,349 @@
+/**
+ * OpenRouter client for the review agent.
+ *
+ * Free models come with three constraints that shape everything here:
+ *
+ *   1. Most of them do not support structured outputs, so we cannot rely on a
+ *      JSON schema being enforced. We ask for JSON, then parse defensively.
+ *   2. The free lineup churns — models appear and disappear weekly. Hardcoding
+ *      IDs guarantees a workflow that breaks silently one morning, so we
+ *      discover what is currently free at runtime and fall back through a chain.
+ *   3. The daily request cap is low (50/day, or 1000 once you have bought $10
+ *      of credit). Requests are a budget to be spent, not a free resource, so
+ *      the diff is packed into as few calls as possible.
+ *
+ * Pure functions live here alongside the client so they can be unit tested
+ * without touching the network.
+ */
+
+const BASE = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+
+/** Rough token estimate. Deliberately pessimistic — overrunning context is worse. */
+export const CHARS_PER_TOKEN = 3.5;
+
+export function estimateTokens(text) {
+  return Math.ceil((text?.length || 0) / CHARS_PER_TOKEN);
+}
+
+/**
+ * Split a unified diff into per-file sections.
+ * @param {string} diff
+ * @returns {Array<{file:string, patch:string}>}
+ */
+export function splitDiffByFile(diff) {
+  if (!diff?.trim()) return [];
+  const out = [];
+  // Keep the `diff --git` header with its section.
+  const sections = diff.split(/(?=^diff --git )/m).filter(s => s.trim());
+  for (const patch of sections) {
+    // `diff --git a/path b/path` — take the b-side, which is the new path.
+    const m = /^diff --git a\/(.+?) b\/(.+?)$/m.exec(patch);
+    out.push({ file: m ? m[2] : 'unknown', patch });
+  }
+  return out;
+}
+
+/**
+ * Pack per-file diffs into as few requests as possible without blowing the
+ * context window.
+ *
+ * A file whose own diff exceeds the budget is truncated rather than dropped —
+ * a partial review of a big file beats no review at all, and the truncation is
+ * marked inline so the model knows not to reason about what it cannot see.
+ *
+ * @param {Array<{file:string, patch:string}>} files
+ * @param {{budgetChars:number, maxChunks:number}} opts
+ * @returns {{chunks:Array<Array<{file:string,patch:string}>>, skipped:string[], truncated:string[]}}
+ */
+export function packChunks(files, { budgetChars, maxChunks }) {
+  const chunks = [];
+  const skipped = [];
+  const truncated = [];
+  let current = [];
+  let currentSize = 0;
+
+  // Smallest first, so one enormous file cannot starve everything behind it.
+  const ordered = [...files].sort((a, b) => a.patch.length - b.patch.length);
+
+  for (const f of ordered) {
+    let patch = f.patch;
+    if (patch.length > budgetChars) {
+      patch =
+        patch.slice(0, budgetChars) + '\n... [diff truncated for length] ...\n';
+      truncated.push(f.file);
+    }
+    if (currentSize + patch.length > budgetChars && current.length) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push({ file: f.file, patch });
+    currentSize += patch.length;
+  }
+  if (current.length) chunks.push(current);
+
+  if (chunks.length > maxChunks) {
+    for (const chunk of chunks.slice(maxChunks))
+      skipped.push(...chunk.map(f => f.file));
+    return { chunks: chunks.slice(0, maxChunks), skipped, truncated };
+  }
+  return { chunks, skipped, truncated };
+}
+
+/**
+ * Recover a JSON object from whatever a free model actually returned.
+ *
+ * Free models routinely wrap JSON in markdown fences, prefix it with "Here is
+ * the review:", or emit <think> blocks first. Without this, roughly a third of
+ * responses would be thrown away.
+ *
+ * @param {string} text
+ * @returns {object|null}
+ */
+export function extractJson(text) {
+  if (typeof text !== 'string' || !text.trim()) return null;
+
+  // Reasoning models emit their scratchpad first.
+  let s = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+  const attempt = candidate => {
+    try {
+      const parsed = JSON.parse(candidate);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed
+        : null;
+    } catch {
+      return null;
+    }
+  };
+
+  let parsed = attempt(s);
+  if (parsed) return parsed;
+
+  // ```json ... ``` fences
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(s);
+  if (fenced) {
+    parsed = attempt(fenced[1].trim());
+    if (parsed) return parsed;
+    s = fenced[1];
+  }
+
+  // Scan for the first balanced object, respecting strings and escapes.
+  const start = s.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < s.length; i++) {
+    const c = s[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (c === '"') inString = !inString;
+    if (inString) continue;
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return attempt(s.slice(start, i + 1));
+    }
+  }
+  return null;
+}
+
+/**
+ * Rank candidate models best-first: structured-output support, then context.
+ *
+ * The whole pipeline depends on the reply parsing as strict JSON, and most free
+ * models cannot guarantee that. Ranking on context alone puts a large-context
+ * model that rambles ahead of a smaller one that answers in the required shape,
+ * and the rambling one then wins the chain and returns nothing usable.
+ *
+ * @param {Array<{id:string, context:number, structured:boolean}>} models
+ */
+export function rankModels(models) {
+  return [...models].sort(
+    (a, b) =>
+      Number(b.structured) - Number(a.structured) || b.context - a.context
+  );
+}
+
+/**
+ * Fetch every model OpenRouter offers, best first, each with a `free` flag.
+ * Fetching is not the spending decision — chooseModels is.
+ *
+ * @param {string} apiKey
+ * @returns {Promise<Array<{id:string, context:number, structured:boolean, free:boolean}>>}
+ */
+export async function listModels(apiKey) {
+  const res = await fetch(`${BASE}/models`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok)
+    throw new Error(
+      `GET /models -> ${res.status}: ${(await res.text()).slice(0, 300)}`
+    );
+  const { data } = await res.json();
+
+  return rankModels(
+    (data || [])
+      .filter(m => typeof m.id === 'string')
+      .map(m => ({
+        id: m.id,
+        context: Number(m.context_length) || 0,
+        structured: (m.supported_parameters || []).includes(
+          'structured_outputs'
+        ),
+        free:
+          m.id.endsWith(':free') ||
+          (Number(m.pricing?.prompt) === 0 &&
+            Number(m.pricing?.completion) === 0),
+      }))
+  );
+}
+
+/**
+ * OpenRouter rejects a `models` fallback array longer than this with a 400.
+ * Every chain that reaches the API is clamped to it.
+ */
+export const MAX_FALLBACK_MODELS = 3;
+
+/**
+ * Choose the model chain to send.
+ *
+ * `preferred` wins whether the model is free or paid — naming a paid model is
+ * the explicit decision to spend. Auto-filled fallbacks are free only, so a
+ * repository that pins nothing can never start billing by itself.
+ *
+ * @param {Array<{id:string, context:number, structured:boolean}>} available
+ * @param {string[]} preferred
+ * @param {number} limit
+ */
+export function chooseModels(
+  available,
+  preferred = [],
+  limit = MAX_FALLBACK_MODELS
+) {
+  const byId = new Map(available.map(m => [m.id, m]));
+  const chain = [];
+  for (const id of preferred) {
+    if (byId.has(id)) chain.push(byId.get(id));
+  }
+  // Only free models auto-fill. Paid ones must be named.
+  for (const m of available.filter(m => m.free !== false)) {
+    if (chain.length >= limit) break;
+    if (!chain.some(c => c.id === m.id)) chain.push(m);
+  }
+  return chain.slice(0, limit);
+}
+
+/**
+ * One chat completion, with OpenRouter's built-in fallback chain.
+ *
+ * OpenRouter falls back through `models` on rate limits, downtime, context
+ * errors and moderation, which covers exactly the failure modes free models
+ * hit. Retries here are only for transport-level problems.
+ *
+ * @param {{apiKey:string, models:string[], system:string, user:string,
+ *          maxTokens?:number, jsonMode?:boolean, retries?:number,
+ *          referer?:string, title?:string}} opts
+ * @returns {Promise<{text:string, model:string, usage:object|null}>}
+ */
+export async function complete(opts) {
+  const {
+    apiKey,
+    models,
+    system,
+    user,
+    maxTokens = 4000,
+    jsonMode = false,
+    retries = 2,
+    referer = 'https://github.com',
+    title = 'PR Review Agent',
+  } = opts;
+
+  const chain = models.slice(0, MAX_FALLBACK_MODELS);
+
+  const body = {
+    model: chain[0],
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: user },
+    ],
+    temperature: 0.1,
+    max_tokens: maxTokens,
+  };
+  if (chain.length > 1) body.models = chain;
+  if (jsonMode) body.response_format = { type: 'json_object' };
+
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(`${BASE}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+          // OpenRouter uses these for attribution on its dashboard.
+          'http-referer': referer,
+          'x-title': title,
+        },
+        body: JSON.stringify(body),
+      });
+
+      const text = await res.text();
+      if (!res.ok) {
+        const retryable = res.status === 429 || res.status >= 500;
+        lastErr = new Error(
+          `POST /chat/completions -> ${res.status}: ${text.slice(0, 400)}`
+        );
+        // A 401/402/400 will never succeed on a retry, and retrying it burns
+        // requests against a daily cap. Mark it so the catch below rethrows
+        // instead of sleeping and trying the same doomed request again.
+        if (!retryable) lastErr.fatal = true;
+        if (!retryable || attempt === retries) throw lastErr;
+        const wait =
+          Number(res.headers.get('retry-after')) * 1000 || 2 ** attempt * 4000;
+        await new Promise(r => setTimeout(r, wait));
+        continue;
+      }
+
+      const json = JSON.parse(text);
+      // OpenRouter can return a 200 whose body carries a provider error.
+      if (json.error)
+        throw new Error(
+          `provider error: ${JSON.stringify(json.error).slice(0, 300)}`
+        );
+      return {
+        text: json.choices?.[0]?.message?.content ?? '',
+        model: json.model || chain[0],
+        usage: json.usage || null,
+      };
+    } catch (err) {
+      lastErr = err;
+      // The non-retryable throw above lands here too, so honour it — otherwise
+      // every 4xx is retried the full count before failing identically.
+      if (err.fatal || attempt === retries) throw lastErr;
+      await new Promise(r => setTimeout(r, 2 ** attempt * 2000));
+    }
+  }
+  throw lastErr;
+}
+
+/** Remaining free-tier allowance, for logging. Never throws. */
+export async function keyStatus(apiKey) {
+  try {
+    const res = await fetch(`${BASE}/key`, {
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) return null;
+    const { data } = await res.json();
+    return data || null;
+  } catch {
+    return null;
+  }
+}

--- a/.github/review/scripts/lib/rules.mjs
+++ b/.github/review/scripts/lib/rules.mjs
@@ -1,0 +1,55 @@
+/**
+ * The rulebook is review-rules.md and nothing else.
+ *
+ * There is no generated companion file, no learned state, no sync step. Edit
+ * the markdown, and the next review uses it. That is the whole contract.
+ */
+
+/** Severity ordering, most severe first. Used for sorting and for the floor. */
+export const SEVERITY_ORDER = { blocker: 0, major: 1, minor: 2, nit: 3 };
+
+export const SEVERITIES = Object.keys(SEVERITY_ORDER);
+
+/**
+ * Pull the rules out of review-rules.md.
+ *
+ * A rule is a bold lead-in of the form:
+ *   **SEC-001 · blocker · Injection via unparameterised query.** Prose...
+ *
+ * Anything else in the file — headings, preamble, notes to humans — is ignored,
+ * so the document stays readable as a document.
+ *
+ * @param {string} markdown
+ * @returns {Array<{id:string, severity:string, title:string}>}
+ */
+export function parseRules(markdown) {
+  const re = /\*\*([A-Z][A-Z0-9]*-\d+)\s*·\s*([a-z]+)\s*·\s*([^*]+?)\*\*/g;
+  const rules = [];
+  const seen = new Set();
+
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    const [, id, severity, rawTitle] = m;
+    if (!SEVERITIES.includes(severity)) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    rules.push({
+      id,
+      severity,
+      title: rawTitle.trim().replace(/\.$/, ''),
+    });
+  }
+  return rules;
+}
+
+/**
+ * One line per rule, for the prompt.
+ *
+ * Deliberately compact: the diff is what deserves the context window, not a
+ * restatement of the rulebook's prose.
+ *
+ * @param {Array<{id:string, severity:string, title:string}>} rules
+ */
+export function buildDigest(rules) {
+  return rules.map(r => `${r.id} [${r.severity}] ${r.title}`).join('\n');
+}

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+/**
+ * Reads the findings Claude produced, gates them against the learned rule
+ * weights, and posts a single PR review.
+ *
+ * Why this is a separate step and not something the model does itself:
+ *   - every posted comment carries a machine-readable marker, so the tuning
+ *     job can attribute human feedback back to a specific rule and finding;
+ *   - the comment cap, the confidence gates and the mute list are enforced
+ *     deterministically rather than being suggestions in a prompt;
+ *   - re-runs on `synchronize` are idempotent — the same finding is never
+ *     posted twice;
+ *   - a line outside the diff cannot 422 the whole review and lose the rest of
+ *     the comments with it.
+ *
+ * Exits non-zero when the PR should not merge: either findings stand against
+ * it, or the review did not actually complete. Both are deliberate — see
+ * BLOCK_ON_FINDINGS and REQUIRE_COMPLETE_REVIEW below.
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  commentableLines,
+  createIssueComment,
+  createReview,
+  getPullFiles,
+  getReviewComments,
+} from './lib/github.mjs';
+import { gateFindings } from './lib/gate.mjs';
+import { parseRules, SEVERITY_ORDER } from './lib/rules.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_PATH = join(HERE, '..', 'review-rules.md');
+const FINDINGS_PATH = '.claude-review/findings.json';
+const MARKER = 'ih-tek-review';
+
+const REPO = process.env.REPO;
+const PR_NUMBER = process.env.PR_NUMBER;
+const HEAD_SHA = process.env.HEAD_SHA;
+const DIFF_TRUNCATED = process.env.DIFF_TRUNCATED === 'true';
+const REQUEST_CHANGES_ON_BLOCKER =
+  process.env.REQUEST_CHANGES_ON_BLOCKER === '1';
+
+/**
+ * When set, unresolved findings make this script exit non-zero, which fails the
+ * check and — with branch protection requiring it — blocks the merge.
+ *
+ * This covers findings specifically. A review that never ran is handled by
+ * REQUIRE_COMPLETE_REVIEW below — the two are separate because they mean
+ * different things to whoever has to clear the check.
+ */
+const BLOCK_ON_FINDINGS = process.env.BLOCK_ON_FINDINGS !== '0';
+
+/** Least severe finding that still blocks. Default: anything at all. */
+const BLOCK_MIN_SEVERITY = process.env.BLOCK_MIN_SEVERITY || 'nit';
+
+/**
+ * When set, a review that did not actually complete fails the check too.
+ *
+ * Without this, a model that returns a well-formed empty result — because it
+ * gave up, or because half the diff never fit in the budget — is
+ * indistinguishable from a genuinely clean review, and quietly unblocks the
+ * merge. A gate that green-lights unread code is not a gate.
+ *
+ * The cost is that a provider outage holds merges until someone re-requests a
+ * review or applies `skip-review`. That is the deliberate trade: the escape
+ * hatch is explicit and visible, rather than a silent pass.
+ */
+const REQUIRE_COMPLETE_REVIEW = process.env.REQUIRE_COMPLETE_REVIEW !== '0';
+
+const SEVERITY_LABEL = {
+  blocker: '🔴 Blocker',
+  major: '🟠 Major',
+  minor: '🟡 Minor',
+  nit: '⚪ Nit',
+};
+
+/** Validate a single finding. Returns an error string, or null if it is fine. */
+function validateFinding(f, i) {
+  if (typeof f !== 'object' || f === null)
+    return `finding[${i}] is not an object`;
+  if (!/^[A-Z]+-\d+$/.test(f.ruleId || ''))
+    return `finding[${i}] has a bad ruleId`;
+  if (typeof f.file !== 'string' || !f.file) return `finding[${i}] has no file`;
+  if (!Number.isInteger(f.line) || f.line < 1)
+    return `finding[${i}] has a bad line`;
+  if (!(f.severity in SEVERITY_ORDER))
+    return `finding[${i}] has a bad severity`;
+  if (typeof f.confidence !== 'number' || f.confidence < 0 || f.confidence > 1)
+    return `finding[${i}] has a bad confidence`;
+  if (typeof f.title !== 'string' || !f.title)
+    return `finding[${i}] has no title`;
+  if (typeof f.body !== 'string' || !f.body) return `finding[${i}] has no body`;
+  return null;
+}
+
+function commentBody(f) {
+  const parts = [
+    `**${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** — ${f.title}`,
+    '',
+    f.body,
+  ];
+
+  if (f.suggestion) {
+    parts.push(
+      '',
+      '```suggestion',
+      f.suggestion.replace(/^```\w*\n?|```$/g, ''),
+      '```'
+    );
+  }
+
+  parts.push(
+    '',
+    `<!-- ${MARKER} rule=${f.ruleId} fid=${f._fid} conf=${f.confidence} sev=${f.severity} -->`
+  );
+  return parts.join('\n');
+}
+
+function summaryBody({
+  summary,
+  kept,
+  dropped,
+  outOfDiff,
+  invalid,
+  ruleCount,
+}) {
+  const counts = { blocker: 0, major: 0, minor: 0, nit: 0 };
+  for (const f of kept) counts[f.severity]++;
+
+  const lines = ['## IH Tek review', ''];
+  lines.push(summary || '_No summary was produced._', '');
+
+  if (kept.length === 0) {
+    // A clean verdict is only honest when something was actually read. The
+    // generator says so in the summary when it reviewed nothing at all.
+    if (!/nothing was reviewed/i.test(summary || '')) {
+      lines.push(
+        'No findings above the confidence threshold. Nothing to flag.'
+      );
+    }
+  } else {
+    lines.push(
+      'Findings: ' +
+        Object.entries(counts)
+          .filter(([, n]) => n > 0)
+          .map(([sev, n]) => `${SEVERITY_LABEL[sev]} ${n}`)
+          .join(' · ')
+    );
+  }
+
+  if (outOfDiff.length) {
+    lines.push(
+      '',
+      '### Findings outside the diff',
+      '',
+      'These could not be attached to a line this PR changed:',
+      ''
+    );
+    for (const f of outOfDiff) {
+      lines.push(`- **${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}`);
+    }
+  }
+
+  const noise = dropped.filter(d => !/already posted/.test(d.reason));
+  if (noise.length) {
+    lines.push(
+      '',
+      '<details><summary>' +
+        noise.length +
+        ' finding(s) suppressed by the feedback loop</summary>',
+      ''
+    );
+    for (const d of noise) {
+      lines.push(
+        `- \`${d.finding.ruleId}\` ${d.finding.file}:${d.finding.line} — ${d.reason}`
+      );
+    }
+    lines.push('', '</details>');
+  }
+
+  if (invalid.length) {
+    lines.push(
+      '',
+      `<sub>${invalid.length} malformed finding(s) discarded: ${invalid.join('; ')}</sub>`
+    );
+  }
+  if (DIFF_TRUNCATED) {
+    lines.push(
+      '',
+      '<sub>⚠️ The diff was truncated for size — later files were not reviewed.</sub>'
+    );
+  }
+
+  lines.push(
+    '',
+    `<sub>${ruleCount} rules — see \`.github/review/review-rules.md\`.</sub>`,
+    `<!-- ${MARKER} summary -->`
+  );
+  return lines.join('\n');
+}
+
+async function main() {
+  if (!REPO || !PR_NUMBER) {
+    console.error('REPO and PR_NUMBER must be set.');
+    return;
+  }
+
+  if (!existsSync(FINDINGS_PATH)) {
+    console.log(
+      'No findings.json was produced — the review step likely failed. Nothing to post.'
+    );
+    failIncomplete('the review step produced no output at all');
+    return;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(FINDINGS_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`findings.json is not valid JSON: ${err.message}`);
+    failIncomplete('the review step produced unreadable output');
+    return;
+  }
+
+  // An explicit false means the generator knows it did not read the whole
+  // diff. Absent (an older findings.json) is treated as reviewed, so this
+  // cannot retroactively block PRs written before the flag existed.
+  const incomplete =
+    payload.reviewed === false
+      ? payload.inconclusive || 'the review did not complete'
+      : null;
+
+  const rules = parseRules(readFileSync(RULES_PATH, 'utf8'));
+  const ruleCount = rules.length;
+
+  // --- validate -----------------------------------------------------------
+  const raw = Array.isArray(payload.findings) ? payload.findings : [];
+  const invalid = [];
+  const valid = [];
+  raw.forEach((f, i) => {
+    const err = validateFinding(f, i);
+    if (err) invalid.push(err);
+    else valid.push(f);
+  });
+  console.log(
+    `Parsed ${valid.length} valid finding(s), ${invalid.length} discarded.`
+  );
+
+  // --- idempotency: what did earlier runs already say? --------------------
+  const existing = await getReviewComments(REPO, PR_NUMBER);
+  const alreadyPosted = new Set();
+  for (const c of existing) {
+    const m = new RegExp(`<!-- ${MARKER} .*?fid=([a-z0-9]+)`).exec(
+      c.body || ''
+    );
+    if (m) alreadyPosted.add(m[1]);
+  }
+  console.log(`${alreadyPosted.size} finding(s) already posted on this PR.`);
+
+  // --- gate against learned weights ---------------------------------------
+  const { kept, dropped } = gateFindings(valid, {
+    alreadyPosted,
+  });
+  console.log(
+    `${kept.length} finding(s) passed the gate, ${dropped.length} dropped.`
+  );
+
+  // What is wrong with this PR *right now*, independent of what earlier runs
+  // already said. `kept` excludes anything already posted, so a re-run where
+  // every problem still stands would otherwise look clean and let the merge
+  // through. The merge decision has to be about the code, not about which
+  // comments happen to be new.
+  const { kept: unresolved } = gateFindings(valid, {
+    alreadyPosted: new Set(),
+  });
+  const blocking = unresolved.filter(
+    f => SEVERITY_ORDER[f.severity] <= SEVERITY_ORDER[BLOCK_MIN_SEVERITY]
+  );
+
+  // --- map to lines GitHub will accept ------------------------------------
+  const files = await getPullFiles(REPO, PR_NUMBER);
+  const lineIndex = new Map();
+  for (const file of files)
+    lineIndex.set(file.filename, commentableLines(file.patch));
+
+  const inline = [];
+  const outOfDiff = [];
+  for (const f of kept) {
+    const allowed = lineIndex.get(f.file);
+    if (!allowed || !allowed.has(f.line)) {
+      outOfDiff.push(f);
+      continue;
+    }
+    const comment = {
+      path: f.file,
+      line: f.line,
+      side: 'RIGHT',
+      body: commentBody(f),
+    };
+    // Multi-line comments need start_line to also be in the diff.
+    if (
+      Number.isInteger(f.endLine) &&
+      f.endLine > f.line &&
+      allowed.has(f.endLine)
+    ) {
+      comment.start_line = f.line;
+      comment.start_side = 'RIGHT';
+      comment.line = f.endLine;
+    }
+    inline.push(comment);
+  }
+  if (outOfDiff.length) {
+    console.log(
+      `${outOfDiff.length} finding(s) fell outside the diff; moved into the summary.`
+    );
+  }
+
+  const hasBlocker = kept.some(f => f.severity === 'blocker');
+  const body = summaryBody({
+    summary: payload.summary,
+    kept,
+    dropped,
+    outOfDiff,
+    invalid,
+    ruleCount,
+  });
+
+  // Nothing new to say and nothing already said: stay quiet.
+  if (inline.length === 0 && outOfDiff.length === 0 && alreadyPosted.size > 0) {
+    console.log('No new findings since the last run. Not posting.');
+    applyMergeGate(blocking, incomplete);
+    return;
+  }
+
+  writeFileSync(
+    '.claude-review/posted.json',
+    JSON.stringify({ inline, outOfDiff, dropped }, null, 2)
+  );
+
+  try {
+    await createReview(REPO, PR_NUMBER, {
+      commitId: HEAD_SHA,
+      body,
+      event:
+        hasBlocker && REQUEST_CHANGES_ON_BLOCKER
+          ? 'REQUEST_CHANGES'
+          : 'COMMENT',
+      comments: inline,
+    });
+    console.log(`Posted a review with ${inline.length} inline comment(s).`);
+  } catch (err) {
+    // The review API is all-or-nothing. Rather than lose the whole review to
+    // one bad line reference, fall back to a single summary comment.
+    console.error(
+      `Inline review failed, falling back to a summary comment: ${err.message}`
+    );
+    const fallback = [
+      body,
+      '',
+      '### Findings',
+      '',
+      ...kept.map(
+        f =>
+          `- **${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}\n\n  ${f.body.replace(/\n/g, '\n  ')}`
+      ),
+    ].join('\n');
+    try {
+      await createIssueComment(REPO, PR_NUMBER, fallback);
+      console.log('Posted the fallback summary comment.');
+    } catch (err2) {
+      console.error(`Fallback comment also failed: ${err2.message}`);
+    }
+  }
+
+  applyMergeGate(blocking, incomplete);
+}
+
+/**
+ * Fail the check when the PR still has findings against it.
+ *
+ * Sets exitCode rather than calling process.exit so the review that was just
+ * posted is not lost to an early teardown.
+ */
+function failIncomplete(reason) {
+  if (!REQUIRE_COMPLETE_REVIEW) {
+    console.log(
+      `Review incomplete (${reason}), but REQUIRE_COMPLETE_REVIEW is off.`
+    );
+    return;
+  }
+  console.error(`\nThe review did not complete: ${reason}.`);
+  console.error(
+    'An absence of findings therefore does not mean this code is clean — it ' +
+      'means it was not read. Re-request a review with the `review-again` ' +
+      'label, or add `skip-review` to merge without one.'
+  );
+  process.exitCode = 1;
+}
+
+function applyMergeGate(blocking, incomplete) {
+  if (incomplete) {
+    // Report the findings we did get, then fail for the ones we may not have.
+    if (blocking.length) {
+      console.error(
+        `${blocking.length} finding(s) posted before the review ran out.`
+      );
+    }
+    failIncomplete(incomplete);
+    return;
+  }
+  if (!blocking.length) {
+    console.log('No unresolved findings. Merge gate is clear.');
+    return;
+  }
+  const counts = {};
+  for (const f of blocking) counts[f.severity] = (counts[f.severity] || 0) + 1;
+  const breakdown = Object.entries(counts)
+    .map(([sev, n]) => `${n} ${sev}`)
+    .join(', ');
+
+  if (!BLOCK_ON_FINDINGS) {
+    console.log(`${blocking.length} unresolved finding(s) (${breakdown}).`);
+    console.log('BLOCK_ON_FINDINGS is off, so this does not fail the check.');
+    return;
+  }
+
+  console.error(
+    `\n${blocking.length} unresolved finding(s) on this pull request: ${breakdown}.`
+  );
+  console.error(
+    'Address them, then re-request a review with the `review-again` label ' +
+      'or a `/review` comment. To merge anyway, add the `skip-review` label.'
+  );
+  process.exitCode = 1;
+}
+
+main().catch(err => {
+  // An API failure before the gate ran means we do not know whether this PR is
+  // clean. Exiting zero here would publish a green check on an unread review.
+  failIncomplete(`post-review failed before the gate ran (${err.message})`);
+  // Log loudly, exit clean. The reviewer is advisory; it must never be the
+  // reason a pull request cannot merge.
+  console.error(`post-review failed: ${err.stack || err.message}`);
+});

--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+/**
+ * Produces .claude-review/findings.json using OpenRouter's free models.
+ *
+ * Drop-in replacement for the Claude Code Action step. It writes the same file
+ * in the same schema, so post-review.mjs, the rule gating and the whole
+ * feedback loop carry on unchanged — only the thing generating the findings
+ * changes.
+ *
+ * The trade versus an agentic reviewer is real and worth stating: this sends
+ * the diff and gets findings back in one shot per chunk. It cannot go and read
+ * the surrounding file, grep for the caller, or check whether a guard exists
+ * elsewhere. Expect more misses on anything that needs repo context, and lean
+ * on the confidence gates to keep the noise down.
+ *
+ * Never exits non-zero. A failed review must not fail anyone's build.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  chooseModels,
+  complete,
+  estimateTokens,
+  extractJson,
+  keyStatus,
+  listModels,
+  MAX_FALLBACK_MODELS,
+  packChunks,
+  splitDiffByFile,
+  CHARS_PER_TOKEN,
+} from './lib/openrouter.mjs';
+import { parseRules, buildDigest } from './lib/rules.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_PATH = join(HERE, '..', 'review-rules.md');
+const OUT_DIR = '.claude-review';
+const DIFF_PATH = join(OUT_DIR, 'pr.diff');
+const FINDINGS_PATH = join(OUT_DIR, 'findings.json');
+const DEBUG_PATH = join(OUT_DIR, 'openrouter-debug.json');
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+const PR_NUMBER = process.env.PR_NUMBER || '0';
+const PR_TITLE = process.env.PR_TITLE || '';
+const PR_BODY = (process.env.PR_BODY || '').slice(0, 1500);
+const MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 4;
+const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 4000;
+const PREFERRED = (process.env.OPENROUTER_MODELS || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+/** Free tier allows 20 requests/minute. Stay comfortably under it. */
+const REQUEST_SPACING_MS = 3500;
+
+/**
+ * Even on a 262k-context model, quality falls off long before the window does.
+ * Capping the chunk keeps a weak model focused on a reviewable amount of code.
+ */
+const MAX_CHUNK_CHARS = 40_000;
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const SYSTEM_PROMPT = `You are a precise code reviewer. You review only the changed lines in a git diff.
+
+You reply with a single JSON object and nothing else. No prose before it, no prose after it, no markdown code fences.
+
+You are strict about false positives. A short review with two real problems is far more valuable than a long one with ten guesses. If you are not confident something is a genuine defect, leave it out.
+
+Never report: formatting or style that a linter handles, naming preferences, missing comments, speculative refactors, praise, or restatements of what the code does.`;
+
+function userPrompt({ digest, chunk, chunkIndex, chunkCount }) {
+  const files = chunk.map(f => f.file).join('\n');
+  const diff = chunk.map(f => f.patch).join('\n');
+
+  return `Review this pull request diff against the rules below.
+
+${PR_TITLE ? `PULL REQUEST TITLE\n${PR_TITLE}\n` : ''}${PR_BODY ? `\nDESCRIPTION\n${PR_BODY}\n` : ''}
+RULES — every finding must cite one of these rule IDs. If you find a real problem that no rule covers, use GEN-000 and name the missing rule in the body.
+
+${digest}
+
+FILES IN THIS BATCH${chunkCount > 1 ? ` (batch ${chunkIndex + 1} of ${chunkCount})` : ''}
+${files}
+
+DIFF
+${diff}
+
+Report only problems in lines this diff ADDS or MODIFIES. Lines starting with "+" are added; lines starting with " " are unchanged context shown for reference only — do not report issues in them.
+
+You are seeing only the diff, not the whole repository. If judging something would require code you cannot see, either lower your confidence accordingly or leave it out.
+
+Reply with exactly this JSON shape:
+
+{
+  "summary": "2-3 sentences on this batch of changes",
+  "findings": [
+    {
+      "ruleId": "SEC-001",
+      "file": "exact path from the FILES list above",
+      "line": 42,
+      "endLine": 42,
+      "severity": "blocker | major | minor | nit",
+      "confidence": 0.85,
+      "title": "one line, under 80 characters",
+      "body": "why this is a problem here and what to do about it",
+      "suggestion": "optional: exact replacement code for those lines, no code fences"
+    }
+  ]
+}
+
+"line" must be the line number in the NEW version of the file, counted from the diff hunk headers (@@ -old,n +new,n @@). Count carefully: added and context lines advance the new-file counter, removed lines do not.
+
+"confidence" is your honest probability from 0 to 1 that an experienced engineer on this codebase would agree this is a real problem. Anything below 0.6 should not be reported at all.
+
+If you find nothing worth reporting, return an empty findings array. That is a perfectly good answer.`;
+}
+
+/** Keep only findings that name a file we actually sent and a rule that exists. */
+function sanitise(findings, chunkFiles, validRuleIds) {
+  const fileSet = new Set(chunkFiles);
+  const out = [];
+  const rejected = [];
+
+  for (const f of Array.isArray(findings) ? findings : []) {
+    if (!f || typeof f !== 'object') continue;
+
+    const ruleId = String(f.ruleId || '')
+      .toUpperCase()
+      .trim();
+    const line = Number.parseInt(f.line, 10);
+    const endLine = Number.parseInt(f.endLine, 10);
+    const severity = String(f.severity || '')
+      .toLowerCase()
+      .trim();
+    const confidence = Number(f.confidence);
+
+    if (!validRuleIds.has(ruleId)) {
+      rejected.push(`invented rule id ${f.ruleId}`);
+      continue;
+    }
+    if (!fileSet.has(f.file)) {
+      rejected.push(`file not in this batch: ${f.file}`);
+      continue;
+    }
+    if (!Number.isInteger(line) || line < 1) {
+      rejected.push(`bad line on ${ruleId}`);
+      continue;
+    }
+    if (!['blocker', 'major', 'minor', 'nit'].includes(severity)) {
+      rejected.push(`bad severity on ${ruleId}`);
+      continue;
+    }
+    if (!Number.isFinite(confidence) || confidence < 0.6) {
+      rejected.push(`confidence below threshold on ${ruleId}`);
+      continue;
+    }
+    if (!f.title || !f.body) {
+      rejected.push(`missing title or body on ${ruleId}`);
+      continue;
+    }
+
+    out.push({
+      ruleId,
+      file: f.file,
+      line,
+      ...(Number.isInteger(endLine) && endLine >= line ? { endLine } : {}),
+      severity,
+      confidence: Math.min(1, Math.max(0, confidence)),
+      title: String(f.title).slice(0, 120),
+      body: String(f.body).slice(0, 4000),
+      ...(f.suggestion
+        ? { suggestion: String(f.suggestion).slice(0, 2000) }
+        : {}),
+    });
+  }
+  return { findings: out, rejected };
+}
+
+function writeFindings(payload) {
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(FINDINGS_PATH, JSON.stringify(payload, null, 2));
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  if (!API_KEY) {
+    console.error('OPENROUTER_API_KEY is not set.');
+    writeFindings({
+      summary: 'Review skipped: no OpenRouter API key configured.',
+      findings: [],
+      reviewed: false,
+      inconclusive: 'no OpenRouter API key is configured',
+    });
+    return;
+  }
+  if (!existsSync(DIFF_PATH)) {
+    console.error(`${DIFF_PATH} is missing.`);
+    writeFindings({
+      summary: 'Review skipped: no diff was produced.',
+      findings: [],
+      reviewed: false,
+      inconclusive: 'the diff could not be produced',
+    });
+    return;
+  }
+
+  const diff = readFileSync(DIFF_PATH, 'utf8');
+  if (!diff.trim()) {
+    writeFindings({
+      summary: 'No reviewable changes in this pull request.',
+      findings: [],
+      reviewed: true,
+    });
+    return;
+  }
+
+  const rules = parseRules(readFileSync(RULES_PATH, 'utf8'));
+  if (rules.length === 0) {
+    writeFindings({
+      summary: 'Review skipped: review-rules.md contains no rules.',
+      findings: [],
+      reviewed: false,
+      inconclusive: 'the rulebook is empty or unparseable',
+    });
+    return;
+  }
+  const digest = buildDigest(rules);
+  const validRuleIds = new Set(rules.map(r => r.id));
+  console.log(`Rulebook: ${rules.length} rule(s) from review-rules.md`);
+
+  // --- pick models --------------------------------------------------------
+  let available;
+  try {
+    available = await listModels(API_KEY);
+  } catch (err) {
+    console.error(`Could not list models: ${err.message}`);
+    writeFindings({
+      summary: `Review skipped: OpenRouter unreachable (${err.message}).`,
+      findings: [],
+      reviewed: false,
+      inconclusive: `OpenRouter was unreachable (${err.message})`,
+    });
+    return;
+  }
+  if (available.length === 0) {
+    writeFindings({
+      summary: 'Review skipped: no usable models are currently available.',
+      findings: [],
+      reviewed: false,
+      inconclusive: 'no usable models were available',
+    });
+    return;
+  }
+
+  const chain = chooseModels(available, PREFERRED, MAX_FALLBACK_MODELS);
+  const minContext = Math.min(...chain.map(m => m.context));
+  const jsonMode = chain.every(m => m.structured);
+  console.log(`Model chain: ${chain.map(m => m.id).join(' -> ')}`);
+  console.log(
+    `Smallest context in chain: ${minContext} tokens. JSON mode: ${jsonMode}.`
+  );
+
+  const status = await keyStatus(API_KEY);
+  if (status) {
+    console.log(
+      `Key usage: ${status.usage ?? '?'} / limit ${status.limit ?? 'none'}` +
+        (status.rate_limit
+          ? ` (${status.rate_limit.requests}/${status.rate_limit.interval})`
+          : '')
+    );
+  }
+
+  // --- chunk the diff -----------------------------------------------------
+  const overheadTokens = estimateTokens(SYSTEM_PROMPT + digest) + 800;
+  const budgetTokens = Math.max(
+    2000,
+    minContext - MAX_OUTPUT_TOKENS - overheadTokens
+  );
+  const budgetChars = Math.min(
+    MAX_CHUNK_CHARS,
+    Math.floor(budgetTokens * CHARS_PER_TOKEN)
+  );
+
+  const files = splitDiffByFile(diff);
+  const { chunks, skipped, truncated } = packChunks(files, {
+    budgetChars,
+    maxChunks: MAX_REQUESTS,
+  });
+  console.log(
+    `${files.length} file(s) -> ${chunks.length} request(s) at ${budgetChars} chars each.` +
+      (truncated.length ? ` Truncated: ${truncated.join(', ')}.` : '') +
+      (skipped.length ? ` Skipped (request cap): ${skipped.join(', ')}.` : '')
+  );
+
+  // --- review -------------------------------------------------------------
+  const all = [];
+  const summaries = [];
+  const debug = [];
+  const seen = new Set();
+  let failures = 0;
+  let repaired = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const chunkFiles = chunk.map(f => f.file);
+    if (i > 0) await sleep(REQUEST_SPACING_MS);
+
+    let result;
+    try {
+      result = await complete({
+        apiKey: API_KEY,
+        models: chain.map(m => m.id),
+        system: SYSTEM_PROMPT,
+        user: userPrompt({
+          digest,
+          chunk,
+          chunkIndex: i,
+          chunkCount: chunks.length,
+        }),
+        maxTokens: MAX_OUTPUT_TOKENS,
+        jsonMode,
+        title: `PR Review #${PR_NUMBER}`,
+      });
+    } catch (err) {
+      console.error(`Batch ${i + 1} failed: ${err.message}`);
+      debug.push({ batch: i + 1, files: chunkFiles, error: err.message });
+      failures++;
+      continue;
+    }
+
+    let parsed = extractJson(result.text);
+
+    // Free models sometimes narrate before the JSON. One cheap repair attempt.
+    if (!parsed) {
+      console.log(
+        `Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`
+      );
+      repaired++;
+      await sleep(REQUEST_SPACING_MS);
+      try {
+        const repair = await complete({
+          apiKey: API_KEY,
+          models: chain.map(m => m.id),
+          system: SYSTEM_PROMPT,
+          user:
+            'Your previous reply was not valid JSON. Return the same content as a single JSON ' +
+            'object with keys "summary" and "findings", and nothing else.\n\n' +
+            'Previous reply:\n' +
+            result.text.slice(0, 6000),
+          maxTokens: MAX_OUTPUT_TOKENS,
+          jsonMode,
+        });
+        parsed = extractJson(repair.text);
+      } catch (err) {
+        console.error(`Batch ${i + 1} repair failed: ${err.message}`);
+      }
+    }
+
+    if (!parsed) {
+      debug.push({
+        batch: i + 1,
+        files: chunkFiles,
+        model: result.model,
+        unparseable: result.text.slice(0, 1200),
+      });
+      failures++;
+      continue;
+    }
+
+    const { findings, rejected } = sanitise(
+      parsed.findings,
+      chunkFiles,
+      validRuleIds
+    );
+    for (const f of findings) {
+      const key = `${f.ruleId}|${f.file}|${f.line}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      all.push(f);
+    }
+    if (parsed.summary) summaries.push(String(parsed.summary).trim());
+
+    console.log(
+      `Batch ${i + 1}/${chunks.length} via ${result.model}: ` +
+        `${findings.length} finding(s) kept, ${rejected.length} rejected.`
+    );
+    // A rejected finding means the model DID find something and we discarded it
+    // — a very different problem from the model finding nothing. Say why here
+    // rather than only in an artifact.
+    for (const reason of [...new Set(rejected)].slice(0, 10)) {
+      console.log(`   rejected: ${reason}`);
+    }
+    debug.push({
+      batch: i + 1,
+      files: chunkFiles,
+      model: result.model,
+      usage: result.usage,
+      kept: findings.length,
+      rejected,
+    });
+  }
+
+  // --- assemble -----------------------------------------------------------
+  const notes = [];
+  if (truncated.length)
+    notes.push(`Large diffs truncated in: ${truncated.join(', ')}.`);
+  if (skipped.length) {
+    notes.push(
+      `Not reviewed — hit the ${MAX_REQUESTS}-request budget: ${skipped.join(', ')}.`
+    );
+  }
+  if (failures === chunks.length) {
+    notes.push(
+      `**Nothing was reviewed.** All ${chunks.length} batch(es) failed, so an absence of ` +
+        `findings below means the diff was never read — not that it is clean. ` +
+        `See the workflow log for the provider error.`
+    );
+  } else if (failures) {
+    notes.push(
+      `${failures} of ${chunks.length} batch(es) failed and were skipped.`
+    );
+  }
+
+  const summary =
+    [summaries.join(' '), notes.join(' ')].filter(Boolean).join('\n\n') ||
+    'No reviewable findings were produced.';
+
+  // --- did the model actually read this diff? -----------------------------
+  //
+  // An empty findings array means one of two very different things: the code
+  // is clean, or the model gave up and said so politely. Those are
+  // indistinguishable downstream, and treating the second as a pass is how an
+  // unreviewed PR sails through a merge gate. Anything short of a complete
+  // read is reported as inconclusive rather than clean.
+  const GAVE_UP =
+    /\bno code (was )?(provided|supplied|given)|\bnothing (was )?(provided|supplied)|\bunable to review|\bcannot review|\bno (diff|changes|content) (was |were )?(provided|supplied|given)/i;
+
+  let inconclusive = null;
+  if (failures === chunks.length) {
+    inconclusive = `all ${chunks.length} batch(es) failed`;
+  } else if (failures) {
+    inconclusive = `${failures} of ${chunks.length} batch(es) failed, so part of the diff was never read`;
+  } else if (skipped.length) {
+    inconclusive = `${skipped.length} file(s) exceeded the ${MAX_REQUESTS}-request budget and were never read: ${skipped.join(', ')}`;
+  } else if (all.length === 0 && GAVE_UP.test(summaries.join(' '))) {
+    inconclusive = 'the model reported that it did not see the code';
+  } else if (all.length === 0 && repaired > 0) {
+    inconclusive = `${repaired} batch(es) returned unparseable output and then found nothing, which usually means the model did not engage with the diff`;
+  }
+
+  if (inconclusive) {
+    console.log(`Review is inconclusive: ${inconclusive}.`);
+  }
+
+  writeFindings({
+    summary,
+    findings: all,
+    reviewed: !inconclusive,
+    ...(inconclusive ? { inconclusive } : {}),
+  });
+  writeFileSync(
+    DEBUG_PATH,
+    JSON.stringify({ chain: chain.map(m => m.id), debug }, null, 2)
+  );
+  console.log(`Wrote ${all.length} finding(s) to ${FINDINGS_PATH}.`);
+}
+
+main().catch(err => {
+  console.error(`openrouter-review failed: ${err.stack || err.message}`);
+  try {
+    writeFindings({
+      summary: `Review failed: ${err.message}`,
+      findings: [],
+      reviewed: false,
+      inconclusive: `the review crashed (${err.message})`,
+    });
+  } catch {
+    /* nothing more we can do */
+  }
+});

--- a/.github/review/scripts/test/gate.test.mjs
+++ b/.github/review/scripts/test/gate.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * The gate is what stops the reviewer flooding a PR. It is small on purpose —
+ * confidence floor, severity floor, dedupe, cap — and these tests are what keep
+ * it that way.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { gateFindings, findingId, MIN_CONFIDENCE } from '../lib/gate.mjs';
+
+const f = (over = {}) => ({
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 10,
+  severity: 'major',
+  confidence: 0.9,
+  title: 't',
+  body: 'b',
+  ...over,
+});
+
+test('a confident finding is kept', () => {
+  const { kept } = gateFindings([f()]);
+  assert.equal(kept.length, 1);
+  assert.ok(kept[0]._fid, 'kept findings carry a stable id');
+});
+
+test('anything below the confidence floor is dropped', () => {
+  const { kept, dropped } = gateFindings([
+    f({ confidence: MIN_CONFIDENCE - 0.01 }),
+  ]);
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /confidence/);
+});
+
+test('the severity floor drops what sits below it', () => {
+  const { kept, dropped } = gateFindings([f({ severity: 'nit' })], {
+    minSeverity: 'major',
+  });
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /below major/);
+  const both = gateFindings(
+    [f({ severity: 'blocker' }), f({ severity: 'nit' })],
+    {
+      minSeverity: 'major',
+    }
+  );
+  assert.equal(both.kept.length, 1);
+  assert.equal(both.kept[0].severity, 'blocker');
+});
+
+test('a finding already on the PR is not posted twice', () => {
+  const finding = f();
+  const { kept, dropped } = gateFindings([finding], {
+    alreadyPosted: new Set([findingId(finding)]),
+  });
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /already posted/);
+});
+
+test('the comment cap keeps the most severe findings', () => {
+  const many = [
+    f({ severity: 'nit', line: 1 }),
+    f({ severity: 'blocker', line: 2 }),
+    f({ severity: 'minor', line: 3 }),
+  ];
+  const { kept } = gateFindings(many, { maxComments: 1 });
+  assert.equal(kept.length, 1);
+  assert.equal(kept[0].severity, 'blocker');
+});
+
+test('at equal severity the more confident finding wins the cap', () => {
+  const { kept } = gateFindings(
+    [f({ line: 1, confidence: 0.7 }), f({ line: 2, confidence: 0.95 })],
+    { maxComments: 1 }
+  );
+  assert.equal(kept[0].line, 2);
+});
+
+test('finding ids are stable across runs but distinguish real differences', () => {
+  assert.equal(findingId(f()), findingId(f()));
+  assert.equal(
+    findingId(f()),
+    findingId(f({ confidence: 0.61, body: 'reworded' })),
+    'wording and confidence must not change identity'
+  );
+  assert.notEqual(findingId(f()), findingId(f({ line: 11 })));
+  assert.notEqual(findingId(f()), findingId(f({ ruleId: 'SEC-002' })));
+});

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -1,0 +1,546 @@
+/**
+ * Tests for the OpenRouter path.
+ *
+ * The pure functions are tested directly; the runner is exercised end to end
+ * against a stub OpenRouter server, because the failure modes that actually
+ * bite with free models — narrated JSON, invented file paths, invented rule
+ * IDs, 429s mid-run — only show up in the full pipeline.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  chooseModels,
+  extractJson,
+  packChunks,
+  rankModels,
+  splitDiffByFile,
+} from '../lib/openrouter.mjs';
+
+const run = promisify(execFile);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, '..', 'review.mjs');
+
+// --- diff splitting --------------------------------------------------------
+
+const DIFF = `diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,4 @@
+ const x = 1;
++const y = 2;
+diff --git a/src/b.ts b/src/b.ts
+index 333..444 100644
+--- a/src/b.ts
++++ b/src/b.ts
+@@ -10,2 +10,3 @@
++const z = 3;
+`;
+
+test('splits a diff into per-file sections keyed by the new path', () => {
+  const files = splitDiffByFile(DIFF);
+  assert.deepEqual(
+    files.map(f => f.file),
+    ['src/a.ts', 'src/b.ts']
+  );
+  assert.match(files[0].patch, /const y = 2/);
+  assert.ok(
+    !files[0].patch.includes('const z = 3'),
+    'sections must not bleed into each other'
+  );
+});
+
+test('a renamed file is keyed by its new path', () => {
+  const renamed =
+    'diff --git a/old/name.ts b/new/name.ts\n--- a/old/name.ts\n+++ b/new/name.ts\n@@ -1 +1 @@\n+x\n';
+  assert.equal(splitDiffByFile(renamed)[0].file, 'new/name.ts');
+});
+
+test('an empty diff yields no sections', () => {
+  assert.deepEqual(splitDiffByFile(''), []);
+  assert.deepEqual(splitDiffByFile('   '), []);
+});
+
+// --- chunk packing ---------------------------------------------------------
+
+const mkFiles = sizes =>
+  sizes.map((n, i) => ({ file: `f${i}.ts`, patch: 'x'.repeat(n) }));
+
+test('small files are packed together into one request', () => {
+  const { chunks } = packChunks(mkFiles([100, 100, 100]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].length, 3);
+});
+
+test('files are split across requests once the budget is exceeded', () => {
+  const { chunks } = packChunks(mkFiles([600, 600, 600]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
+  assert.equal(chunks.length, 3);
+});
+
+test('a file larger than the budget is truncated rather than dropped', () => {
+  const { chunks, truncated } = packChunks(mkFiles([5000]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
+  assert.deepEqual(truncated, ['f0.ts']);
+  assert.equal(chunks.length, 1);
+  assert.match(chunks[0][0].patch, /diff truncated for length/);
+  assert.ok(chunks[0][0].patch.length <= 1100);
+});
+
+test('the request cap reports what it dropped instead of silently truncating', () => {
+  const { chunks, skipped } = packChunks(mkFiles([900, 900, 900, 900]), {
+    budgetChars: 1000,
+    maxChunks: 2,
+  });
+  assert.equal(chunks.length, 2);
+  assert.equal(skipped.length, 2);
+});
+
+test('one huge file does not starve the small ones behind it', () => {
+  // With only one request available and a file that fills the whole budget,
+  // the small file must still be the one that gets reviewed.
+  const { chunks, skipped } = packChunks(
+    [
+      { file: 'big.ts', patch: 'x'.repeat(1000) },
+      { file: 'small.ts', patch: 'y'.repeat(10) },
+    ],
+    { budgetChars: 1000, maxChunks: 1 }
+  );
+  assert.deepEqual(
+    chunks[0].map(f => f.file),
+    ['small.ts']
+  );
+  assert.deepEqual(skipped, ['big.ts']);
+});
+
+// --- JSON recovery ---------------------------------------------------------
+
+const OBJ = '{"summary":"ok","findings":[]}';
+
+test('parses a clean JSON reply', () => {
+  assert.deepEqual(extractJson(OBJ), { summary: 'ok', findings: [] });
+});
+
+test('recovers JSON from markdown fences', () => {
+  assert.deepEqual(extractJson('```json\n' + OBJ + '\n```'), {
+    summary: 'ok',
+    findings: [],
+  });
+  assert.deepEqual(extractJson('```\n' + OBJ + '\n```'), {
+    summary: 'ok',
+    findings: [],
+  });
+});
+
+test('recovers JSON despite narration before and after', () => {
+  const narrated = `Sure! Here is my review:\n\n${OBJ}\n\nLet me know if you need more detail.`;
+  assert.deepEqual(extractJson(narrated), { summary: 'ok', findings: [] });
+});
+
+test('strips a reasoning model scratchpad', () => {
+  assert.deepEqual(
+    extractJson(`<think>Let me look at this...</think>\n${OBJ}`),
+    {
+      summary: 'ok',
+      findings: [],
+    }
+  );
+});
+
+test('handles braces inside strings without losing the object', () => {
+  const tricky = 'Here:\n{"summary":"use {a: 1} instead","findings":[]}\nDone.';
+  assert.equal(extractJson(tricky).summary, 'use {a: 1} instead');
+});
+
+test('handles escaped quotes inside strings', () => {
+  const tricky = '{"summary":"he said \\"hi\\" then left","findings":[]}';
+  assert.equal(extractJson(tricky).summary, 'he said "hi" then left');
+});
+
+test('returns null rather than guessing on unusable output', () => {
+  assert.equal(extractJson('I cannot review this.'), null);
+  assert.equal(extractJson(''), null);
+  assert.equal(extractJson(null), null);
+  assert.equal(extractJson('{"broken": '), null);
+  assert.equal(
+    extractJson('[1,2,3]'),
+    null,
+    'a bare array is not the expected shape'
+  );
+});
+
+// --- model selection -------------------------------------------------------
+
+const AVAILABLE = [
+  { id: 'big/model:free', context: 262144, structured: false },
+  { id: 'mid/model:free', context: 128000, structured: true },
+  { id: 'small/model:free', context: 32000, structured: false },
+];
+
+test('preferred models lead the chain when they are still available', () => {
+  const chain = chooseModels(AVAILABLE, ['mid/model:free'], 3);
+  assert.equal(chain[0].id, 'mid/model:free');
+  assert.equal(chain.length, 3, 'the rest are appended as fallbacks');
+});
+
+test('a preferred model that no longer exists is skipped, not fatal', () => {
+  const chain = chooseModels(
+    AVAILABLE,
+    ['retired/model:free', 'small/model:free'],
+    2
+  );
+  assert.equal(chain[0].id, 'small/model:free');
+});
+
+test('with no preference the largest context comes first', () => {
+  assert.equal(chooseModels(AVAILABLE, [], 1)[0].id, 'big/model:free');
+});
+
+test('the chain never exceeds the requested length', () => {
+  assert.equal(chooseModels(AVAILABLE, [], 2).length, 2);
+});
+
+test('a model that guarantees JSON outranks a bigger one that does not', () => {
+  // The regression this locks in: ranking on context alone put a 262k model
+  // with no structured-output support ahead of a 128k model that had it, and
+  // the big one returned prose the parser could not read.
+  const ranked = rankModels(AVAILABLE);
+  assert.equal(ranked[0].id, 'mid/model:free');
+  assert.ok(
+    ranked.every(
+      (m, i) => i === 0 || !m.structured || ranked[i - 1].structured
+    ),
+    'every structured model sorts ahead of every unstructured one'
+  );
+});
+
+test('among equally capable models the larger context still wins', () => {
+  const ranked = rankModels([
+    { id: 'small/structured:free', context: 8000, structured: true },
+    { id: 'large/structured:free', context: 262144, structured: true },
+  ]);
+  assert.equal(ranked[0].id, 'large/structured:free');
+});
+
+test('ranking does not mutate the caller array', () => {
+  const input = [...AVAILABLE];
+  rankModels(input);
+  assert.deepEqual(
+    input.map(m => m.id),
+    AVAILABLE.map(m => m.id)
+  );
+});
+
+// --- end to end ------------------------------------------------------------
+
+async function startStub({ replies, models = AVAILABLE }) {
+  const calls = [];
+  let i = 0;
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      const send = (code, payload) => {
+        res.writeHead(code, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      };
+      if (req.url.endsWith('/models')) {
+        return send(200, {
+          data: models.map(m => ({
+            id: m.id,
+            context_length: m.context,
+            supported_parameters: m.structured ? ['structured_outputs'] : [],
+          })),
+        });
+      }
+      if (req.url.endsWith('/key'))
+        return send(200, { data: { usage: 1, limit: null } });
+      if (req.url.endsWith('/chat/completions')) {
+        calls.push(JSON.parse(body));
+        const reply = replies[Math.min(i++, replies.length - 1)];
+        if (reply.status && reply.status !== 200)
+          return send(reply.status, { error: reply.body });
+        return send(200, {
+          model: reply.model || 'big/model:free',
+          choices: [{ message: { content: reply.content } }],
+          usage: { total_tokens: 100 },
+        });
+      }
+      send(404, {});
+    });
+  });
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  return { server, calls, port: server.address().port };
+}
+
+async function runReview(stub, { diff = DIFF, rules, env = {} } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'or-review-'));
+  await mkdir(join(dir, '.claude-review'), { recursive: true });
+  await writeFile(join(dir, '.claude-review', 'pr.diff'), diff);
+
+  // The script reads review-rules.md relative to itself, so point it at a copy
+  // only when the test needs different rules.
+  let scriptPath = SCRIPT;
+  if (rules) {
+    const reviewDir = join(dir, 'review');
+    await mkdir(join(reviewDir, 'scripts', 'lib'), { recursive: true });
+    await writeFile(join(reviewDir, 'review-rules.md'), rules);
+    for (const f of ['review.mjs']) {
+      await writeFile(
+        join(reviewDir, 'scripts', f),
+        await readFile(join(HERE, '..', f))
+      );
+    }
+    for (const f of ['openrouter.mjs', 'rules.mjs', 'gate.mjs']) {
+      await writeFile(
+        join(reviewDir, 'scripts', 'lib', f),
+        await readFile(join(HERE, '..', 'lib', f))
+      );
+    }
+    scriptPath = join(reviewDir, 'scripts', 'review.mjs');
+  }
+
+  const { stdout, stderr } = await run(process.execPath, [scriptPath], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      OPENROUTER_BASE_URL: `http://127.0.0.1:${stub.port}`,
+      OPENROUTER_API_KEY: 'stub-key',
+      PR_NUMBER: '7',
+      ...env,
+    },
+  });
+  const findings = JSON.parse(
+    await readFile(join(dir, '.claude-review', 'findings.json'), 'utf8')
+  );
+  await rm(dir, { recursive: true, force: true });
+  return { stdout, stderr, findings };
+}
+
+const RULES_FILE = `# Rulebook
+
+**SEC-001 · blocker · Injection.** String concatenation building SQL.
+`;
+
+const goodFinding = {
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 2,
+  severity: 'blocker',
+  confidence: 0.9,
+  title: 'SQL injection',
+  body: 'Parameterise this.',
+};
+
+test('produces findings.json in the schema post-review.mjs expects', async () => {
+  const stub = await startStub({
+    replies: [
+      {
+        content: JSON.stringify({
+          summary: 'Looks risky.',
+          findings: [goodFinding],
+        }),
+      },
+    ],
+  });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1);
+    assert.equal(findings.findings[0].ruleId, 'SEC-001');
+    assert.match(findings.summary, /Looks risky/);
+    assert.equal(typeof findings.findings[0].confidence, 'number');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('narrated and fenced replies still yield findings', async () => {
+  const stub = await startStub({
+    replies: [
+      {
+        content:
+          'Sure!\n```json\n' +
+          JSON.stringify({ summary: 's', findings: [goodFinding] }) +
+          '\n```\nHope that helps!',
+      },
+    ],
+  });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('invented rule IDs and file paths are discarded', async () => {
+  const stub = await startStub({
+    replies: [
+      {
+        content: JSON.stringify({
+          summary: 's',
+          findings: [
+            { ...goodFinding, ruleId: 'MADE-UP-1' },
+            { ...goodFinding, file: 'src/does-not-exist.ts' },
+            { ...goodFinding, confidence: 0.2 },
+            { ...goodFinding, severity: 'catastrophic' },
+            goodFinding,
+          ],
+        }),
+      },
+    ],
+  });
+  try {
+    const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(
+      findings.findings.length,
+      1,
+      'only the valid finding survives'
+    );
+    assert.match(stdout, /4 rejected/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('an unparseable reply triggers exactly one repair attempt', async () => {
+  const stub = await startStub({
+    replies: [
+      { content: 'I am unable to produce JSON right now.' },
+      {
+        content: JSON.stringify({
+          summary: 'recovered',
+          findings: [goodFinding],
+        }),
+      },
+    ],
+  });
+  try {
+    const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
+    assert.match(stdout, /retrying once/);
+    assert.equal(findings.findings.length, 1);
+    assert.equal(stub.calls.length, 2);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a rate limited batch degrades to a partial review, not a crash', async () => {
+  const stub = await startStub({
+    replies: [{ status: 429, body: { message: 'rate limited' } }],
+  });
+  try {
+    const { findings, stderr } = await runReview(stub, {
+      rules: RULES_FILE,
+      env: { MAX_REQUESTS: '1' },
+    });
+    assert.deepEqual(findings.findings, []);
+    assert.match(findings.summary, /failed/i);
+    assert.match(stderr, /429/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a missing API key writes an empty review instead of failing the job', async () => {
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    const { findings } = await runReview(stub, {
+      rules: RULES_FILE,
+      env: { OPENROUTER_API_KEY: '' },
+    });
+    assert.deepEqual(findings.findings, []);
+    assert.match(findings.summary, /no OpenRouter API key/i);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the request budget is respected and what was dropped is reported', async () => {
+  const many = Array.from(
+    { length: 6 },
+    (_, i) =>
+      `diff --git a/f${i}.ts b/f${i}.ts\n--- a/f${i}.ts\n+++ b/f${i}.ts\n@@ -1 +1,2 @@\n+${'x'.repeat(30000)}\n`
+  ).join('');
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
+  });
+  try {
+    const { findings, stdout } = await runReview(stub, {
+      diff: many,
+      rules: RULES_FILE,
+      env: { MAX_REQUESTS: '2' },
+    });
+    assert.equal(stub.calls.length, 2, 'never exceeds the request budget');
+    assert.match(stdout, /Skipped \(request cap\)/);
+    assert.match(findings.summary, /request budget/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the fallback chain is sent so OpenRouter can reroute on rate limits', async () => {
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
+  });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    assert.ok(
+      Array.isArray(stub.calls[0].models),
+      'models array must be present'
+    );
+    assert.ok(stub.calls[0].models.length > 1, 'needs at least one fallback');
+    assert.equal(stub.calls[0].temperature, 0.1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('JSON mode is only requested when every model in the chain supports it', async () => {
+  const mixed = await startStub({
+    replies: [{ content: OBJ }],
+    models: [
+      { id: 'a:free', context: 100000, structured: true },
+      { id: 'b:free', context: 90000, structured: false },
+    ],
+  });
+  try {
+    await runReview(mixed, { rules: RULES_FILE });
+    assert.equal(
+      mixed.calls[0].response_format,
+      undefined,
+      'would 400 on the non-supporting fallback'
+    );
+  } finally {
+    mixed.server.close();
+  }
+
+  const allStructured = await startStub({
+    replies: [{ content: OBJ }],
+    models: [{ id: 'a:free', context: 100000, structured: true }],
+  });
+  try {
+    await runReview(allStructured, { rules: RULES_FILE });
+    assert.deepEqual(allStructured.calls[0].response_format, {
+      type: 'json_object',
+    });
+  } finally {
+    allStructured.server.close();
+  }
+});

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -1,0 +1,422 @@
+/**
+ * End-to-end test for post-review.mjs against a stub GitHub API.
+ *
+ * Runs the real script as a child process with GITHUB_API_URL pointed at a
+ * local server, so the whole path — parse, validate, gate, diff-map, post — is
+ * exercised without touching the network. This is what catches the failures
+ * that unit tests on pure functions cannot: a wrong request body, a comment on
+ * a line outside the diff, or a crash on malformed model output.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const run = promisify(execFile);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, '..', 'post-review.mjs');
+
+const PATCH = [
+  '@@ -1,3 +1,5 @@',
+  ' const a = 1;',
+  '+const b = 2;',
+  '+const c = 3;',
+  ' const d = 4;',
+].join('\n');
+
+/** Stub GitHub API. Records every request so the test can assert on them. */
+async function startStub({ existingComments = [], failReview = false } = {}) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      requests.push({
+        method: req.method,
+        url: req.url,
+        body: body ? JSON.parse(body) : null,
+      });
+      const send = (code, payload) => {
+        res.writeHead(code, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      };
+
+      if (req.url.startsWith('/repos/acme/app/pulls/7/comments'))
+        return send(200, existingComments);
+      if (req.url.startsWith('/repos/acme/app/pulls/7/files')) {
+        return send(200, [{ filename: 'src/a.ts', patch: PATCH }]);
+      }
+      if (req.url.startsWith('/repos/acme/app/pulls/7/reviews')) {
+        return failReview
+          ? send(422, { message: 'line must be part of the diff' })
+          : send(200, { id: 1 });
+      }
+      if (req.url.startsWith('/repos/acme/app/issues/7/comments'))
+        return send(201, { id: 2 });
+      send(404, { message: 'not found' });
+    });
+  });
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  return { server, requests, port: server.address().port };
+}
+
+async function runPostReview(findings, stub, env = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-review-'));
+  await mkdir(join(dir, '.claude-review'), { recursive: true });
+  if (findings !== null) {
+    await writeFile(
+      join(dir, '.claude-review', 'findings.json'),
+      typeof findings === 'string' ? findings : JSON.stringify(findings)
+    );
+  }
+  // execFile rejects on a non-zero exit, and a non-zero exit is now a normal
+  // outcome — it is how the merge gate reports unresolved findings. Capture the
+  // code instead of letting it throw.
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    ({ stdout, stderr } = await run(process.execPath, [SCRIPT], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        GITHUB_API_URL: `http://127.0.0.1:${stub.port}`,
+        GITHUB_TOKEN: 'stub-token',
+        REPO: 'acme/app',
+        PR_NUMBER: '7',
+        HEAD_SHA: 'deadbeef',
+        BLOCK_ON_FINDINGS: '0',
+        ...env,
+      },
+    }));
+  } catch (err) {
+    ({ stdout = '', stderr = '' } = err);
+    exitCode = err.code ?? 1;
+  }
+  await rm(dir, { recursive: true, force: true });
+  return { stdout, stderr, exitCode };
+}
+
+const findingsPayload = findings => ({
+  summary: 'Looks reasonable overall.',
+  findings,
+});
+
+const base = {
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 2,
+  severity: 'blocker',
+  confidence: 0.9,
+  title: 'SQL built by string concatenation',
+  body: 'Use a parameterised query here.',
+};
+
+test('posts one review with an inline comment on a line inside the diff', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([base]), stub);
+    const review = stub.requests.find(
+      r => r.method === 'POST' && r.url.includes('/reviews')
+    );
+    assert.ok(review, 'a review should have been posted');
+    assert.equal(review.body.commit_id, 'deadbeef');
+    assert.equal(review.body.event, 'COMMENT');
+    assert.equal(review.body.comments.length, 1);
+    assert.equal(review.body.comments[0].path, 'src/a.ts');
+    assert.equal(review.body.comments[0].line, 2);
+    assert.equal(review.body.comments[0].side, 'RIGHT');
+    assert.match(
+      review.body.comments[0].body,
+      /<!-- ih-tek-review rule=SEC-001 fid=\w+/
+    );
+    assert.match(review.body.body, /## IH Tek review/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a finding outside the diff is moved into the summary, not sent inline', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([{ ...base, line: 999 }]), stub);
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
+    assert.equal(
+      review.body.comments.length,
+      0,
+      'must not send an out-of-diff line'
+    );
+    assert.match(review.body.body, /Findings outside the diff/);
+    assert.match(review.body.body, /src\/a\.ts:999/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('REQUEST_CHANGES only when explicitly enabled', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([base]), stub, {
+      REQUEST_CHANGES_ON_BLOCKER: '1',
+    });
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
+    assert.equal(review.body.event, 'REQUEST_CHANGES');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a finding already posted on an earlier run is not reposted', async () => {
+  const existing = [
+    {
+      id: 100,
+      body:
+        'old\n<!-- ih-tek-review rule=SEC-001 fid=' +
+        (await import('../lib/gate.mjs')).findingId(base) +
+        ' -->',
+    },
+  ];
+  const stub = await startStub({ existingComments: existing });
+  try {
+    const { stdout } = await runPostReview(findingsPayload([base]), stub);
+    assert.match(stdout, /No new findings since the last run/);
+    assert.equal(stub.requests.filter(r => r.method === 'POST').length, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('falls back to a plain comment when the inline review is rejected', async () => {
+  const stub = await startStub({ failReview: true });
+  try {
+    const { stdout } = await runPostReview(findingsPayload([base]), stub);
+    const fallback = stub.requests.find(r =>
+      r.url.includes('/issues/7/comments')
+    );
+    assert.ok(fallback, 'should fall back rather than lose the review');
+    assert.match(fallback.body.body, /SQL built by string concatenation/);
+    assert.match(stdout, /fallback/i);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('malformed model output is discarded without crashing', async () => {
+  const stub = await startStub();
+  try {
+    const { stdout } = await runPostReview(
+      findingsPayload([
+        { ...base, ruleId: 'lowercase-id' },
+        { ...base, line: 'not a number' },
+        { ...base, severity: 'catastrophic' },
+        { ...base, confidence: 7 },
+        base,
+      ]),
+      stub
+    );
+    assert.match(stdout, /Parsed 1 valid finding\(s\), 4 discarded/);
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
+    assert.equal(review.body.comments.length, 1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('invalid JSON and a missing file are both survivable', async () => {
+  for (const input of ['{ not json', null]) {
+    const stub = await startStub();
+    try {
+      const { stdout, stderr } = await runPostReview(input, stub);
+      assert.equal(stub.requests.filter(r => r.method === 'POST').length, 0);
+      assert.ok(/not valid JSON|No findings.json/.test(stdout + stderr));
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+// --- merge gate ------------------------------------------------------------
+
+test('unresolved findings fail the check so the merge is blocked', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode, stderr } = await runPostReview(
+      findingsPayload([base]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 1, 'a finding must fail the check');
+    assert.match(stderr, /1 unresolved finding\(s\)/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a clean PR does not block the merge', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode, stdout } = await runPostReview(
+      findingsPayload([]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 0);
+    assert.match(stdout, /Merge gate is clear/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('findings already posted still block on a re-run', async () => {
+  // The regression this guards: `kept` excludes anything a previous run already
+  // commented on, so gating on it would let a PR whose every problem still
+  // stands sail through the second time it is checked.
+  const existing = [
+    {
+      id: 100,
+      body:
+        'old\n<!-- ih-tek-review rule=SEC-001 fid=' +
+        (await import('../lib/gate.mjs')).findingId(base) +
+        ' -->',
+    },
+  ];
+  const stub = await startStub({ existingComments: existing });
+  try {
+    const { exitCode, stdout } = await runPostReview(
+      findingsPayload([base]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.match(stdout, /No new findings since the last run/);
+    assert.equal(
+      exitCode,
+      1,
+      'the problem still exists, so it must still block'
+    );
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('BLOCK_MIN_SEVERITY lets nits through while majors still block', async () => {
+  for (const [severity, expected] of [
+    ['nit', 0],
+    ['major', 1],
+  ]) {
+    const stub = await startStub();
+    try {
+      const { exitCode } = await runPostReview(
+        findingsPayload([{ ...base, severity, confidence: 0.95 }]),
+        stub,
+        { BLOCK_ON_FINDINGS: '1', BLOCK_MIN_SEVERITY: 'major' }
+      );
+      assert.equal(exitCode, expected, `severity ${severity}`);
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+// --- incomplete reviews ----------------------------------------------------
+
+test('a review that did not complete does not pass the gate', async () => {
+  // The hole this closes: a model that returns a well-formed empty result
+  // because it gave up looks identical to a genuinely clean review, and would
+  // otherwise unblock the merge on code nothing ever read.
+  const stub = await startStub();
+  try {
+    const { exitCode, stderr } = await runPostReview(
+      {
+        summary: 'No code was provided for review.',
+        findings: [],
+        reviewed: false,
+        inconclusive: 'the model reported that it did not see the code',
+      },
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 1, 'an unread diff must not read as clean');
+    assert.match(stderr, /did not complete/);
+    assert.match(stderr, /did not see the code/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a completed clean review still passes', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(
+      { summary: 'Looks fine.', findings: [], reviewed: true },
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('findings.json without the flag is treated as reviewed', async () => {
+  // Older output has no `reviewed` key. Absent must not mean "incomplete", or
+  // upgrading would retroactively block every open PR.
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(findingsPayload([]), stub, {
+      BLOCK_ON_FINDINGS: '1',
+    });
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a missing or unreadable findings.json blocks rather than passes', async () => {
+  for (const input of ['{ not json', null]) {
+    const stub = await startStub();
+    try {
+      const { exitCode, stderr } = await runPostReview(input, stub, {
+        BLOCK_ON_FINDINGS: '1',
+      });
+      assert.equal(exitCode, 1, 'no output means nothing was reviewed');
+      assert.match(stderr, /did not complete/);
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+test('REQUIRE_COMPLETE_REVIEW=0 restores the advisory behaviour', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(
+      { summary: 'gave up', findings: [], reviewed: false },
+      stub,
+      { BLOCK_ON_FINDINGS: '1', REQUIRE_COMPLETE_REVIEW: '0' }
+    );
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a clean PR still gets a short summary', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([]), stub);
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
+    assert.equal(review.body.comments.length, 0);
+    assert.match(
+      review.body.body,
+      /No findings above the confidence threshold/
+    );
+  } finally {
+    stub.server.close();
+  }
+});

--- a/.github/review/scripts/test/rules.test.mjs
+++ b/.github/review/scripts/test/rules.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * The rulebook is the only input a human edits, and it is parsed out of prose.
+ * These tests pin the parse so a formatting slip in review-rules.md cannot
+ * silently drop a rule from every future review.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { parseRules, buildDigest, SEVERITY_ORDER } from '../lib/rules.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULEBOOK = join(HERE, '..', '..', 'review-rules.md');
+
+test('parses id, severity and title out of a rule line', () => {
+  const rules = parseRules(
+    '**SEC-001 · blocker · Injection via unparameterised query.** String concat.'
+  );
+  assert.deepEqual(rules, [
+    {
+      id: 'SEC-001',
+      severity: 'blocker',
+      title: 'Injection via unparameterised query',
+    },
+  ]);
+});
+
+test('ignores prose, headings and anything that is not a rule', () => {
+  const md = `# Rulebook
+
+Some preamble about how to edit this file.
+
+## SEC — Security
+
+**SEC-001 · blocker · Injection.** Prose here.
+
+Not a rule: **bold text** in the middle of a paragraph.
+`;
+  assert.deepEqual(
+    parseRules(md).map(r => r.id),
+    ['SEC-001']
+  );
+});
+
+test('rejects a severity the gate would not understand', () => {
+  // A typo like "critical" must drop the rule loudly-by-absence rather than
+  // producing a rule the gate can never rank.
+  const rules = parseRules('**SEC-002 · critical · Something.** Prose.');
+  assert.deepEqual(rules, []);
+});
+
+test('a duplicated id keeps only the first definition', () => {
+  const rules = parseRules(
+    '**SEC-001 · blocker · First.** x\n**SEC-001 · minor · Second.** y'
+  );
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0].severity, 'blocker');
+});
+
+test('accepts multi-word prefixes and multi-digit numbers', () => {
+  const rules = parseRules('**ASYNC-012 · major · Race condition.** x');
+  assert.equal(rules[0].id, 'ASYNC-012');
+});
+
+test('the digest is one compact line per rule', () => {
+  const digest = buildDigest([
+    { id: 'SEC-001', severity: 'blocker', title: 'Injection' },
+    { id: 'FE-005', severity: 'minor', title: 'Index key' },
+  ]);
+  assert.equal(digest, 'SEC-001 [blocker] Injection\nFE-005 [minor] Index key');
+});
+
+// --- the real rulebook -----------------------------------------------------
+
+test('the shipped rulebook parses and every rule is usable', () => {
+  const rules = parseRules(readFileSync(RULEBOOK, 'utf8'));
+  assert.ok(rules.length > 0, 'review-rules.md must yield rules');
+  for (const r of rules) {
+    assert.match(r.id, /^[A-Z][A-Z0-9]*-\d+$/, `bad id: ${r.id}`);
+    assert.ok(r.severity in SEVERITY_ORDER, `bad severity on ${r.id}`);
+    assert.ok(r.title.length > 0, `no title on ${r.id}`);
+  }
+  assert.equal(
+    new Set(rules.map(r => r.id)).size,
+    rules.length,
+    'rule ids must be unique'
+  );
+});

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,207 @@
+name: PR Review
+
+# Automated PR review using OpenRouter free models.
+#
+# The model only runs when somebody asks for it, by adding the `review-again`
+# label. Opening a PR or pushing to one costs nothing.
+#
+# But the check still reports on every pull_request event, because it is a
+# REQUIRED check and a required check that never reports leaves a PR
+# unmergeable forever. So:
+#
+#   PR opened / reopened / ready   -> check RED  "review not requested"   0 requests
+#   push to an open PR             -> check RED  "code changed"           0 requests
+#   `review-again` label           -> full review, RED on findings        <=4 requests
+#                                     or GREEN when clean
+#   draft / skip-review / other base -> check GREEN, gate bypassed        0 requests
+#
+# A push always sends the check back to red. That is the point: a review that
+# passed against code which has since changed must not keep a merge unblocked.
+#
+# There is deliberately no `/review` comment trigger. A comment handler can only
+# request a review by applying the label, and GitHub does not start workflow
+# runs from events created by GITHUB_TOKEN — so the `labeled` event never fires
+# and the comment silently does nothing. Enabling it needs a PAT or GitHub App
+# token; the label works today and needs neither.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    # Base branch, i.e. what the PR merges INTO. PRs targeting anything else
+    # (qa, staging, feature branches) are not reviewed and are not gated.
+    branches: [main, dev]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Every pull_request event runs this job, including the ones that do no
+    # work. A required check must always report, or the PR can never merge.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Decide what this run should do
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          DATA=$(gh pr view "$NUMBER" --repo "$REPO" \
+            --json headRefOid,baseRefOid,baseRefName,isDraft,labels,state)
+
+          BASE_REF=$(echo "$DATA" | jq -r .baseRefName)
+          IS_DRAFT=$(echo "$DATA" | jq -r .isDraft)
+          STATE=$(echo "$DATA" | jq -r .state)
+          SKIP=$(echo "$DATA" | jq -r '[.labels[].name] | index("skip-review") // ""')
+
+          # --- bypass: report green, spend nothing -----------------------------
+          if [ "$STATE" != "OPEN" ] || [ "$IS_DRAFT" = "true" ] || [ -n "$SKIP" ]; then
+            echo "Not gating #${NUMBER} (state=${STATE} draft=${IS_DRAFT} skip=${SKIP:-no})."
+            echo "mode=bypass" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # --- review: somebody asked for one ----------------------------------
+          if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "review-again" ]; then
+            {
+              echo "mode=review"
+              echo "number=${NUMBER}"
+              echo "head_sha=$(echo "$DATA" | jq -r .headRefOid)"
+              echo "base_sha=$(echo "$DATA" | jq -r .baseRefOid)"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reviewing #${NUMBER} into ${BASE_REF}."
+            exit 0
+          fi
+
+          # --- a label we do not act on: leave the check as it was --------------
+          if [ "$ACTION" = "labeled" ]; then
+            echo "Labeled '${LABEL_NAME}'. Not a review request."
+            echo "mode=bypass" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # --- pending: no review has been requested for this code -------------
+          echo "mode=pending" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.pr.outputs.mode == 'review'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        if: steps.pr.outputs.mode == 'review'
+        with:
+          node-version: '20'
+
+      - name: Prepare diff
+        if: steps.pr.outputs.mode == 'review'
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude-review
+
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+
+          git diff --unified=3 "$MERGE_BASE" "$HEAD_SHA" \
+            -- . ':(exclude)**/*.lock' ':(exclude)**/package-lock.json' \
+               ':(exclude)**/yarn.lock' ':(exclude)**/pnpm-lock.yaml' \
+               ':(exclude)**/*.snap' ':(exclude)**/dist/**' \
+               ':(exclude)**/build/**' ':(exclude)**/*.min.js' \
+            > .claude-review/pr.diff
+
+          git diff --name-status "$MERGE_BASE" "$HEAD_SHA" > .claude-review/changed-files.txt
+          echo "Diff: $(wc -c < .claude-review/pr.diff) bytes, $(wc -l < .claude-review/changed-files.txt) file(s)."
+
+      - name: Generate findings
+        if: steps.pr.outputs.mode == 'review'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODELS: ${{ vars.OPENROUTER_MODELS }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          # Passed as env, not interpolated into a shell command — a PR title is
+          # attacker-controlled text and must never reach a `run:` block inline.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          MAX_REQUESTS: '4'
+        run: node .github/review/scripts/review.mjs
+
+      - name: Post review
+        if: steps.pr.outputs.mode == 'review'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          REQUEST_CHANGES_ON_BLOCKER: '0'
+          # Unresolved findings fail this step, which fails the check, which
+          # blocks the merge. Only findings do this — every reviewer failure
+          # path still exits zero, so a provider outage cannot wedge merges.
+          # ENFORCEMENT SWITCH — owner-controlled, repo variable REVIEW_ENFORCE.
+          # Unset or anything but 'true' = advisory: the review still runs and
+          # still comments, it just never fails the check. Set REVIEW_ENFORCE to
+          # 'true' when the rulebook has earned the right to block merges.
+          BLOCK_ON_FINDINGS: ${{ vars.REVIEW_ENFORCE == 'true' && '1' || '0' }}
+          REQUIRE_COMPLETE_REVIEW: ${{ vars.REVIEW_ENFORCE == 'true' && '1' || '0' }}
+          # Least severe finding that still blocks: blocker | major | minor | nit
+          BLOCK_MIN_SEVERITY: 'nit'
+        run: node .github/review/scripts/post-review.mjs
+
+      - name: Clear the review-again label
+        # Removed so it can be applied again. A label that stays put can only
+        # trigger once, which is a confusing way for an on-demand switch to fail.
+        if: always() && steps.pr.outputs.mode == 'review'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/labels/review-again" \
+            --silent || true
+
+      - name: Upload artifacts
+        if: always() && steps.pr.outputs.mode == 'review'
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-${{ steps.pr.outputs.number }}
+          path: .claude-review/
+          retention-days: 14
+          if-no-files-found: warn
+          # .claude-review is a dot-directory and upload-artifact@v4 skips hidden
+          # paths by default — without this the artifact is silently empty.
+          include-hidden-files: true
+
+      - name: No review has been requested for this code
+        if: steps.pr.outputs.mode == 'pending'
+        env:
+          ENFORCE: ${{ vars.REVIEW_ENFORCE == 'true' && '1' || '0' }}
+        run: |
+          if [ "$ENFORCE" != "1" ]; then
+            echo "::notice title=Review not requested::Advisory mode — add the \`review-again\` label for a review. Not blocking."
+            exit 0
+          fi
+          echo "::error title=Review not requested::This pull request has not been reviewed at its current commit."
+          cat <<'MSG'
+          The automated review has not run against this code.
+
+          Ask for one, and this check turns green if it comes back clean:
+
+            * add the `review-again` label
+
+          Pushing new commits sends this check back to red on purpose — a review
+          that passed against code you have since changed should not keep the
+          merge unblocked.
+          MSG
+          exit 1

--- a/README.md
+++ b/README.md
@@ -105,6 +105,65 @@ VITE_APP_ENV=production
 
 **Note:** `VITE_SENTRY_DSN` is only required in production. Sentry is automatically disabled in development for better performance.
 
+## 🤖 Automated PR Review
+
+Pull requests into `main` or `dev` are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 64 rules in twelve categories:
+
+| Prefix  | Covers                                             | Prefix | Covers                                   |
+| ------- | -------------------------------------------------- | ------ | ---------------------------------------- |
+| `SEC`   | Security                                           | `TS`   | TypeScript and code health               |
+| `PHI`   | Patient and personal data                          | `OPS`  | Configuration, deployment, observability |
+| `DATA`  | Databases, ORMs, migrations                        | `API`  | Interfaces and contracts                 |
+| `ASYNC` | Async, errors, and control flow                    | `TEST` | Tests                                    |
+| `RT`    | Realtime: Socket.IO and WebRTC                     | `STD`  | Project standards from this README       |
+| `FE`    | Frontend: React, Angular, Vue, Ionic, React Native | `GEN`  | Uncategorised                            |
+
+### Requesting a review
+
+Add the **`review-again`** label to your PR. Nothing runs when you open a PR or push to it — you ask when you want it.
+
+| You do                            | What happens                                         |
+| --------------------------------- | ---------------------------------------------------- |
+| Open a PR / push a commit         | Check goes red: _review not requested_. Nothing runs |
+| Add the **`review-again`** label  | Full review. Red if it finds something, green if not |
+| Fix the findings, add label again | Re-reviews the new code                              |
+
+> **Currently in evaluation mode.** The reviewer runs and comments, but does not block anything.
+> Everything below describes what happens once enforcement is switched on — the repo owner does that
+> by setting the `REVIEW_ENFORCE` variable to `true`.
+
+### What blocks a merge
+
+Two independent gates, and it is worth knowing they are separate:
+
+| Gate                       | Cleared by                                        | Enforced by              |
+| -------------------------- | ------------------------------------------------- | ------------------------ |
+| The `review` check         | Fixing the code, then asking for a fresh review   | This workflow            |
+| Unresolved review comments | Clicking **Resolve conversation** on every thread | GitHub branch protection |
+
+**Resolving a comment does not clear the check.** The reviewer recomputes from the current diff each time — if the code still has the problem, the next review finds it again. Resolve the thread _and_ fix the code.
+
+A push always resets the check to red: a review that passed against code you have since changed should not keep the merge open.
+
+### Re-reviewing after you fix something
+
+Add the **`review-again`** label again. It is removed automatically after each run, so it is always ready to re-apply — that is the whole loop:
+
+```
+push fix  →  check goes red  →  add `review-again`  →  fresh review
+```
+
+### Adding a rule
+
+Edit [.github/review/review-rules.md](.github/review/review-rules.md) — that file is the entire configuration. There is no generated companion file and no sync step to run. Format is one bold line plus prose:
+
+```markdown
+**FE-008 · minor · Inline styles on a new component.** Style via the project's
+CSS modules instead, so theming stays in one place.
+```
+
+Severity (`blocker | major | minor | nit`) decides what survives the comment cap and what the merge gate blocks on. Design notes: [.github/review/README.md](.github/review/README.md).
+
 ## 📁 Project Structure
 
 ```

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -63,6 +63,12 @@ export default defineConfig({
     env: {
       VITE_OPENMRS_API_URL: 'http://localhost:8080/openmrs/ws/rest/v1',
     },
+    /**
+     * Scope vitest to the app. Without this its default glob sweeps the whole
+     * repo and picks up .github/review/scripts/test/*.test.mjs, which are
+     * node:test files and fail with "No test suite found".
+     */
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules/**', 'dist/**', 'coverage/**', 'src/examples/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Adds an automated PR reviewer that comments against a written rulebook.

**Advisory only — it cannot block anything.** It runs when asked, comments, and always reports green. Enforcement is one repo variable away once the findings prove worth acting on.

**How to use it:** add the `review-again` label to a PR. Opening a PR or pushing to one does nothing until you ask.

**Configuration is one file:** `.github/review/review-rules.md` — 66 rules across security, PHI, data, async, frontend, TypeScript, tests, ops and project standards. Edit the markdown; there is no generated file and no sync step.

**One source change:** `vitest.config.ts` gains an `include` scope. It had none, so vitest's default glob swept the whole repo and picked up the reviewer's `node:test` files. Verified: 293 test files pass, matching `dev`.

No npm dependencies — the scripts run on the Node 20 already on `ubuntu-latest`.

Needs an `OPENROUTER_API_KEY` secret and an `OPENROUTER_MODELS` variable before it does anything.
