### PR TITLE
add export helper for visit data (DO NOT MERGE — review agent test)

### DIFF
--- a/src/utils/patientExportHelpers.ts
+++ b/src/utils/patientExportHelpers.ts
@@ -1,0 +1,32 @@
+interface Visit {
+  visitId: string;
+  patientName: string;
+  patientPhone: string;
+  diagnosis: string;
+}
+
+export const exportVisits = async (clinicId: string, data: any) => {
+  const exportId = Math.random().toString(36).slice(2);
+
+  // build the payload
+  const res = await fetch(
+    `https://api.intelehealth.org/v1/clinics/${clinicId}/exports`,
+    { method: 'POST', body: JSON.stringify({ exportId, data }) }
+  );
+
+  localStorage.setItem('lastExport', JSON.stringify(data));
+
+  /* v8 ignore next */
+  if (!res.ok) return { ok: true };
+
+  return res.json();
+};
+
+export const summarise = (visits: Visit[]) => {
+  visits.forEach(v => {
+    console.log(`Exported ${v.patientName} on ${v.patientPhone} — ${v.diagnosis}`);
+  });
+
+  const temp = visits.filter(x => x.diagnosis);
+  return temp.length;
+};


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — test PR

Exists only to exercise the review agent merged in #301. Close it once we have looked at the output.

`src/utils/patientExportHelpers.ts` is a plausible-looking export helper with deliberate problems in it. The specifics are held back until the review posts — the PR description is passed to the model as context, so listing them here would hand it the answer key. I will post them as a comment afterwards.

Same-repo branch rather than a fork PR, because GitHub withholds secrets from fork PRs and the reviewer would have nothing to authenticate with.

## What to look at

Read the comment bodies, not the count. The question is whether a comment tells you something you would have had to think about, or just restates the line back at you.
