### PR TITLE
review pull requests on open by default

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -11,16 +11,17 @@ outside this repo. Ask the owner (**@Zeeshan-IH**) if you need it.
 
 ## When it runs
 
-The model runs only when somebody asks, by adding the **`review-again`** label. Opening a
-PR or pushing to one costs nothing.
+A pull request is reviewed automatically when it is opened. Pushing to it does not
+re-review — that only marks the result stale; add the **`review-again`** label for a
+fresh one.
 
 The check still reports on every `pull_request` event, because it is a required check and
 one that never reports leaves a PR unmergeable forever:
 
 | Event                              | Check                         | Requests |
 | ---------------------------------- | ----------------------------- | -------- |
-| PR opened / reopened / ready       | 🔴 review not requested       | 0        |
-| Push to an open PR                 | 🔴 code changed               | 0        |
+| PR opened / reopened / ready       | 🔴 on findings, 🟢 when clean | ≤ 4      |
+| Push to an open PR                 | 🔴 review is stale            | 0        |
 | `review-again` label               | 🔴 on findings, 🟢 when clean | ≤ 4      |
 | Draft, or a PR into another branch | 🟢 not gated                  | 0        |
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,17 +2,18 @@ name: PR Review
 
 # Automated PR review using OpenRouter free models.
 #
-# The model only runs when somebody asks for it, by adding the `review-again`
-# label. Opening a PR or pushing to one costs nothing.
+# A pull request is reviewed automatically when it is opened. Pushing to it does
+# not re-review — that only marks the existing review stale; add the
+# `review-again` label when you want a fresh one.
 #
 # But the check still reports on every pull_request event, because it is a
 # REQUIRED check and a required check that never reports leaves a PR
 # unmergeable forever. So:
 #
-#   PR opened / reopened / ready   -> check RED  "review not requested"   0 requests
-#   push to an open PR             -> check RED  "code changed"           0 requests
-#   `review-again` label           -> full review, RED on findings        <=4 requests
+#   PR opened / reopened / ready   -> full review, RED on findings        <=4 requests
 #                                     or GREEN when clean
+#   push to an open PR             -> check RED  "review is stale"        0 requests
+#   `review-again` label           -> re-review                           <=4 requests
 #   draft / skip-review / other base -> check GREEN, gate bypassed        0 requests
 #
 # A push always sends the check back to red. That is the point: a review that
@@ -72,8 +73,14 @@ jobs:
             echo "mode=bypass" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          # --- review: somebody asked for one ----------------------------------
-          if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "review-again" ]; then
+          # --- review: opened by default, or somebody asked again --------------
+          #
+          # A PR is reviewed on sight. `review-again` re-reviews after a push,
+          # since `synchronize` deliberately does not spend a review on every
+          # commit — it only sends the check back to red.
+          if [ "$ACTION" = "opened" ] || [ "$ACTION" = "reopened" ] \
+             || [ "$ACTION" = "ready_for_review" ] \
+             || { [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "review-again" ]; }; then
             {
               echo "mode=review"
               echo "number=${NUMBER}"
@@ -189,16 +196,15 @@ jobs:
           ENFORCE: ${{ vars.REVIEW_ENFORCE == 'true' && '1' || '0' }}
         run: |
           if [ "$ENFORCE" != "1" ]; then
-            echo "::notice title=Review not requested::Advisory mode — add the \`review-again\` label for a review. Not blocking."
+            echo "::notice title=Review is stale::Advisory mode — add the \`review-again\` label for a fresh review. Not blocking."
             exit 0
           fi
-          echo "::error title=Review not requested::This pull request has not been reviewed at its current commit."
+          echo "::error title=Review is stale::This pull request has changed since it was last reviewed."
           cat <<'MSG'
-          The automated review has not run against this code.
+          The code has changed since the last review, so the previous result no
+          longer applies.
 
-          Ask for one, and this check turns green if it comes back clean:
-
-            * add the `review-again` label
+          Add the `review-again` label for a fresh review.
 
           Pushing new commits sends this check back to red on purpose — a review
           that passed against code you have since changed should not keep the

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ VITE_APP_ENV=production
 
 ## 🤖 Automated PR Review
 
-Pull requests into `main` or `dev` are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 64 rules in twelve categories:
+Pull requests into `main` or `dev` are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 67 rules in twelve categories:
 
 | Prefix  | Covers                                             | Prefix | Covers                                   |
 | ------- | -------------------------------------------------- | ------ | ---------------------------------------- |
@@ -118,19 +118,19 @@ Pull requests into `main` or `dev` are reviewed against a written rulebook at [.
 | `RT`    | Realtime: Socket.IO and WebRTC                     | `STD`  | Project standards from this README       |
 | `FE`    | Frontend: React, Angular, Vue, Ionic, React Native | `GEN`  | Uncategorised                            |
 
-### Requesting a review
+### How it runs
 
-Add the **`review-again`** label to your PR. Nothing runs when you open a PR or push to it — you ask when you want it.
+**Every PR is reviewed automatically when you open it.** No label needed.
 
-| You do                            | What happens                                         |
-| --------------------------------- | ---------------------------------------------------- |
-| Open a PR / push a commit         | Check goes red: _review not requested_. Nothing runs |
-| Add the **`review-again`** label  | Full review. Red if it finds something, green if not |
-| Fix the findings, add label again | Re-reviews the new code                              |
+| You do                 | What happens                                         |
+| ---------------------- | ---------------------------------------------------- |
+| Open a PR              | Reviewed automatically. Red if it finds something    |
+| Push a commit          | Check goes red: the review is stale. Nothing re-runs |
+| Add **`review-again`** | Fresh review of the new code                         |
 
-> **Currently in evaluation mode.** The reviewer runs and comments, but does not block anything.
-> Everything below describes what happens once enforcement is switched on — the repo owner does that
-> by setting the `REVIEW_ENFORCE` variable to `true`.
+Pushing does not re-review on its own — that would spend a review on every
+commit. It marks the existing result stale so a passing review cannot cover code
+you have since changed.
 
 ### What blocks a merge
 
@@ -144,14 +144,6 @@ Two independent gates, and it is worth knowing they are separate:
 **Resolving a comment does not clear the check.** The reviewer recomputes from the current diff each time — if the code still has the problem, the next review finds it again. Resolve the thread _and_ fix the code.
 
 A push always resets the check to red: a review that passed against code you have since changed should not keep the merge open.
-
-### Re-reviewing after you fix something
-
-Add the **`review-again`** label again. It is removed automatically after each run, so it is always ready to re-apply — that is the whole loop:
-
-```
-push fix  →  check goes red  →  add `review-again`  →  fresh review
-```
 
 ### Adding a rule
 


### PR DESCRIPTION
Follow-up to #301.

Previously a PR was only reviewed when someone added the `review-again` label, so a PR opened without it passed straight through unreviewed. Now every PR is reviewed when it is opened, reopened, or marked ready for review.

Pushing to an open PR still does **not** re-review — it marks the existing result stale and turns the check red. Re-reviewing on every commit would spend a review per push against a capped budget; the label is how you ask for a fresh one.

| Event | Before | Now |
| --- | --- | --- |
| PR opened | 🔴 review not requested, 0 requests | **full review** |
| Push to an open PR | 🔴 code changed | 🔴 review is stale |
| `review-again` label | full review | full review |

Docs updated to match, and the check message now says "review is stale" rather than "not requested", which was misleading once opening a PR reviews it.