### PR TITLE
prefer non-reasoning models and raise the output budget

### DIFF
--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -158,8 +158,9 @@ export function extractJson(text) {
 /**
  * Rank candidate models best-first: structured-output support, then context.
  *
- * The whole pipeline depends on the reply parsing as strict JSON, and most free
- * models cannot guarantee that. Ranking on context alone puts a large-context
+ * Structured output first, then non-reasoning, then context. The pipeline needs
+ * strict JSON in a bounded reply; a reasoning model can spend the whole output
+ * budget thinking and return a truncated fragment. Ranking on context alone puts a large-context
  * model that rambles ahead of a smaller one that answers in the required shape,
  * and the rambling one then wins the chain and returns nothing usable.
  *
@@ -168,7 +169,9 @@ export function extractJson(text) {
 export function rankModels(models) {
   return [...models].sort(
     (a, b) =>
-      Number(b.structured) - Number(a.structured) || b.context - a.context
+      Number(b.structured) - Number(a.structured) ||
+      Number(a.reasoning) - Number(b.reasoning) ||
+      b.context - a.context
   );
 }
 
@@ -198,6 +201,10 @@ export async function listModels(apiKey) {
         structured: (m.supported_parameters || []).includes(
           'structured_outputs'
         ),
+        // Reasoning models spend the output budget thinking before replying, so
+        // they need far more headroom for the same answer. Rank them below an
+        // equally capable non-reasoning model rather than excluding them.
+        reasoning: (m.supported_parameters || []).includes('reasoning'),
         free:
           m.id.endsWith(':free') ||
           (Number(m.pricing?.prompt) === 0 &&

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -544,3 +544,25 @@ test('JSON mode is only requested when every model in the chain supports it', as
     allStructured.server.close();
   }
 });
+
+test('a non-reasoning model outranks a reasoning one at equal capability', () => {
+  // The regression this locks in: deepseek-v4-pro spent 4000 of 4001 completion
+  // tokens reasoning and replied "No diff was provided for review."
+  const ranked = rankModels([
+    { id: 'thinker:v1', context: 1000000, structured: true, reasoning: true },
+    { id: 'answerer:v1', context: 262144, structured: true, reasoning: false },
+  ]);
+  assert.equal(ranked[0].id, 'answerer:v1');
+});
+
+test('structured output still outranks non-reasoning', () => {
+  const ranked = rankModels([
+    { id: 'plain:v1', context: 262144, structured: false, reasoning: false },
+    { id: 'thinker:v1', context: 262144, structured: true, reasoning: true },
+  ]);
+  assert.equal(
+    ranked[0].id,
+    'thinker:v1',
+    'JSON support is the harder constraint'
+  );
+});

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -137,6 +137,12 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           MAX_REQUESTS: '4'
+          # Reasoning models spend this budget thinking before they answer, and
+          # what is left is the reply. At 4000 a reasoning model can burn the
+          # lot on reasoning and return a truncated fragment — observed on
+          # deepseek-v4-pro: 4000 of 4001 completion tokens were reasoning, and
+          # the reply was the single line "No diff was provided for review."
+          MAX_OUTPUT_TOKENS: '16000'
         run: node .github/review/scripts/review.mjs
 
       - name: Post review


### PR DESCRIPTION
Diagnosis from the review artifact on #303:

```
completion_tokens:  4001
reasoning_tokens:   4000
summary: "No diff was provided for review."
```

`deepseek/deepseek-v4-pro` is a reasoning model. It spent the entire 4,000-token output budget thinking and had ~1 token left for the answer, so the first reply was truncated and the repair attempt only produced a give-up line. `prompt_tokens: 1978` confirms the diff **was** sent — "no diff was provided" is the model hallucinating after being cut off. Cost $0.0155 to produce nothing.

Two changes:

- `MAX_OUTPUT_TOKENS` 4000 → 16000, so a reasoning model has room to think *and* answer.
- `rankModels` now sorts structured-output first, then **non-reasoning**, then context. Reasoning models are ranked lower rather than excluded — they work fine given headroom.

Also worth changing outside this PR: `OPENROUTER_MODELS` currently leads with a reasoning model. Reordering to put `qwen/qwen3-coder` first (non-reasoning, coding specialist, and a third of the price) avoids paying for reasoning tokens on every review.