### PR TITLE
Enforce reply shape with a strict json_schema and disable model reasoning

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -20,9 +20,9 @@ one that never reports leaves a PR unmergeable forever:
 
 | Event                              | Check                         | Requests |
 | ---------------------------------- | ----------------------------- | -------- |
-| PR opened / reopened / ready       | 🔴 on findings, 🟢 when clean | ≤ 4      |
+| PR opened / reopened / ready       | 🔴 on findings, 🟢 when clean | ≤ 6      |
 | Push to an open PR                 | 🔴 review is stale            | 0        |
-| `review-again` label               | 🔴 on findings, 🟢 when clean | ≤ 4      |
+| `review-again` label               | 🔴 on findings, 🟢 when clean | ≤ 6      |
 | Draft, or a PR into another branch | 🟢 not gated                  | 0        |
 
 A push always sends the check back to red: a review that passed against code you have
@@ -116,7 +116,7 @@ leaves no trace of having been skipped.
 cannot open a config file or grep for a caller, so rules needing repo context miss more
 often. This is the biggest constraint — see the handoff for what would fix it.
 
-**Large diffs cap out** at 4 requests × 40,000 chars. Beyond that, files are dropped and
+**Large diffs cap out** at 6 requests × 40,000 chars. Beyond that, files are dropped and
 the review reports inconclusive. Raise `MAX_REQUESTS` or split the PR.
 
 **Fork PRs are skipped** — GitHub withholds secrets from those runs.

--- a/.github/review/scripts/lib/gate.mjs
+++ b/.github/review/scripts/lib/gate.mjs
@@ -14,6 +14,15 @@ export const MIN_CONFIDENCE = 0.6;
 /** Never bury a reviewer under one PR's worth of comments. */
 export const MAX_COMMENTS = 12;
 
+/*
+ * The same rule firing on the same file is one observation, not six. A run
+ * posted six near-identical GEN-000 comments on one file — each individually
+ * valid, collectively noise, and every extra comment is paid output tokens on
+ * the next run too, because posted comments come back as context. Two per
+ * (rule, file) keeps the pattern visible; the summary notes the rest exist.
+ */
+export const MAX_PER_RULE_FILE = 2;
+
 /** FNV-1a. Short, stable, and enough to tell two findings apart. */
 export function hash32(str) {
   let h = 0x811c9dc5;
@@ -47,11 +56,13 @@ export function gateFindings(findings, opts = {}) {
     minConfidence = MIN_CONFIDENCE,
     minSeverity = 'nit',
     maxComments = MAX_COMMENTS,
+    maxPerRuleFile = MAX_PER_RULE_FILE,
   } = opts;
 
   const floor = SEVERITY_ORDER[minSeverity] ?? SEVERITY_ORDER.nit;
   const kept = [];
   const dropped = [];
+  const perRuleFile = new Map();
 
   // Most severe first, then most confident, so the comment cap keeps the
   // findings that matter rather than whichever the model happened to list.
@@ -76,6 +87,14 @@ export function gateFindings(findings, opts = {}) {
       dropped.push({ finding: f, reason: 'already posted' });
       continue;
     }
+    const rfKey = `${f.ruleId}|${f.file}`;
+    if ((perRuleFile.get(rfKey) ?? 0) >= maxPerRuleFile) {
+      dropped.push({
+        finding: f,
+        reason: `more than ${maxPerRuleFile} × ${f.ruleId} on ${f.file}`,
+      });
+      continue;
+    }
     if (kept.length >= maxComments) {
       dropped.push({
         finding: f,
@@ -83,6 +102,7 @@ export function gateFindings(findings, opts = {}) {
       });
       continue;
     }
+    perRuleFile.set(rfKey, (perRuleFile.get(rfKey) ?? 0) + 1);
     kept.push({ ...f, _fid: fid });
   }
 

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -286,8 +286,19 @@ export async function complete(opts) {
     ],
     temperature: 0.1,
     max_tokens: maxTokens,
+    // Ask for OpenRouter's own accounting in every reply, rather than relying
+    // on the provider including it by default.
+    usage: { include: true },
   };
   if (chain.length > 1) body.models = chain;
+
+  /*
+   * One model id is served by several providers at different prices, and the
+   * default routing balances price against uptime. Two identical runs came
+   * back ~70% apart per token because of it. Input tokens are ~99% of this
+   * workload, so the provider's rate is effectively the whole bill.
+   */
+  body.provider = { sort: 'price' };
   /*
    * `json_object` guarantees syntactically valid JSON and nothing else — the
    * model is free to name the keys whatever it likes. Observed in production:
@@ -357,9 +368,13 @@ export async function complete(opts) {
         text: json.choices?.[0]?.message?.content ?? '',
         model: json.model || chain[0],
         usage: json.usage || null,
+        // The exact body sent, for the debug artifact. The API key travels in
+        // a header, never in the body, so this is safe to persist.
+        request: body,
       };
     } catch (err) {
       lastErr = err;
+      lastErr.request = body;
       // The non-retryable throw above lands here too, so honour it — otherwise
       // every 4xx is retried the full count before failing identically.
       if (err.fatal || attempt === retries) throw lastErr;

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -256,7 +256,8 @@ export function chooseModels(
  * hit. Retries here are only for transport-level problems.
  *
  * @param {{apiKey:string, models:string[], system:string, user:string,
- *          maxTokens?:number, jsonMode?:boolean, retries?:number,
+ *          maxTokens?:number, jsonMode?:boolean, schema?:object|null,
+ *          disableReasoning?:boolean, retries?:number,
  *          referer?:string, title?:string}} opts
  * @returns {Promise<{text:string, model:string, usage:object|null}>}
  */
@@ -268,6 +269,8 @@ export async function complete(opts) {
     user,
     maxTokens = 4000,
     jsonMode = false,
+    schema = null,
+    disableReasoning = true,
     retries = 2,
     referer = 'https://github.com',
     title = 'PR Review Agent',
@@ -285,7 +288,32 @@ export async function complete(opts) {
     max_tokens: maxTokens,
   };
   if (chain.length > 1) body.models = chain;
-  if (jsonMode) body.response_format = { type: 'json_object' };
+  /*
+   * `json_object` guarantees syntactically valid JSON and nothing else — the
+   * model is free to name the keys whatever it likes. Observed in production:
+   * a reply keyed `rule_id` instead of `ruleId` parsed cleanly, then every
+   * finding was thrown away as "invented rule id undefined". `json_schema`
+   * with strict:true is what actually pins the field names down.
+   */
+  if (schema && jsonMode) {
+    body.response_format = {
+      type: 'json_schema',
+      json_schema: { name: 'review_findings', strict: true, schema },
+    };
+  } else if (jsonMode) {
+    body.response_format = { type: 'json_object' };
+  }
+
+  /*
+   * Reading a diff and emitting findings against a fixed rulebook is
+   * pattern-matching, not multi-step deduction — there is nothing here for a
+   * chain of thought to work out. Left on, a reasoning model spends the whole
+   * output budget thinking and returns a truncated fragment: deepseek-v4-pro
+   * burned 4000 of 4001 completion tokens and replied "No diff was provided
+   * for review." OpenRouter normalises this across providers and ignores it on
+   * models that cannot reason, so it is safe to send unconditionally.
+   */
+  if (disableReasoning) body.reasoning = { enabled: false };
 
   let lastErr;
   for (let attempt = 0; attempt <= retries; attempt++) {

--- a/.github/review/scripts/notify-slack.mjs
+++ b/.github/review/scripts/notify-slack.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Posts a digest of one review run to Slack, for debugging.
+ *
+ * Includes truncated previews of what was sent to and returned by the model.
+ * The payload contains the diff — source code of a clinical codebase — and a
+ * webhook URL is a bearer credential with no scoping, so this must only ever
+ * point at a private channel. Full, untruncated copies of every request and
+ * response live in the run artifact (openrouter-debug.json); the previews
+ * exist so most debugging never needs the download.
+ *
+ * Never exits non-zero. A failed notification must not fail a review.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+
+const WEBHOOK = process.env.SLACK_WEBHOOK_URL;
+const REPO = process.env.REPO || '';
+const PR_NUMBER = process.env.PR_NUMBER || '';
+const RUN_ID = process.env.RUN_ID || '';
+const PR_AUTHOR = process.env.PR_AUTHOR || '';
+const SERVER = process.env.GITHUB_SERVER_URL || 'https://github.com';
+
+const DEBUG_PATH = '.claude-review/openrouter-debug.json';
+const FINDINGS_PATH = '.claude-review/findings.json';
+
+/*
+ * A fetch failure can quote the URL it was given verbatim — a malformed
+ * webhook lands in the workflow log as itself, and Actions' secret masking
+ * only catches the exact stored value. Nothing logged here may contain it.
+ */
+const scrub = text => String(text).replaceAll(WEBHOOK, '[webhook]');
+
+const readJson = path => {
+  try {
+    return existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Sum the usage fields across batches; they are per-request. */
+function totalUsage(batches) {
+  const t = { prompt: 0, completion: 0, reasoning: 0, cost: 0 };
+  for (const b of batches) {
+    const u = b.usage;
+    if (!u) continue;
+    t.prompt += u.prompt_tokens || 0;
+    t.completion += u.completion_tokens || 0;
+    t.reasoning += u.completion_tokens_details?.reasoning_tokens || 0;
+    t.cost += u.cost || 0;
+  }
+  return t;
+}
+
+async function main() {
+  if (!WEBHOOK) {
+    console.log('No SLACK_WEBHOOK_URL configured; skipping the Slack digest.');
+    return;
+  }
+
+  const debug = readJson(DEBUG_PATH);
+  const findings = readJson(FINDINGS_PATH);
+  const batches = debug?.debug ?? [];
+  const usage = totalUsage(batches);
+
+  const failed = batches.filter(b => b.error).length;
+  const unparseable = batches.filter(b => b.unparseable).length;
+  const kept = batches.reduce((n, b) => n + (b.kept || 0), 0);
+  const rejected = batches.reduce((n, b) => n + (b.rejected?.length || 0), 0);
+  const served = [...new Set(batches.map(b => b.model).filter(Boolean))];
+
+  const inconclusive =
+    findings?.reviewed === false ? findings.inconclusive : null;
+  const status = inconclusive
+    ? '🔴 inconclusive'
+    : kept > 0
+      ? `🟠 ${kept} finding(s)`
+      : '🟢 clean';
+
+  const clip = (text, max) =>
+    text.length > max
+      ? `${text.slice(0, max)}\n… ${text.length - max} more chars, full copy in the artifact`
+      : text;
+
+  const prUrl = `${SERVER}/${REPO}/pull/${PR_NUMBER}`;
+  const runUrl = `${SERVER}/${REPO}/actions/runs/${RUN_ID}`;
+
+  const lines = [
+    `*Review ${status}* — <${prUrl}|${REPO}#${PR_NUMBER}>`,
+    '',
+    ...(PR_AUTHOR ? [`*Raised by:* \`${PR_AUTHOR}\``] : []),
+    `*Chain:* \`${(debug?.chain ?? []).join(' → ') || 'unknown'}\``,
+    `*Served by:* \`${served.join(', ') || 'nothing'}\``,
+    `*Batches:* ${batches.length}` +
+      (failed ? ` · ${failed} failed` : '') +
+      (unparseable ? ` · ${unparseable} unparseable` : ''),
+    `*Findings:* ${kept} kept, ${rejected} rejected by validation`,
+    `*Tokens:* ${usage.prompt} in, ${usage.completion} out` +
+      (usage.reasoning ? ` (${usage.reasoning} reasoning)` : '') +
+      ` · $${usage.cost.toFixed(4)}`,
+    // What OpenRouter actually charged the key for this run, measured as the
+    // key's usage after minus before — the source of truth, not a sum of
+    // per-request numbers.
+    ...(debug?.account?.billed != null
+      ? [
+          `*OpenRouter billed:* $${debug.account.billed.toFixed(4)} this run · ` +
+            `$${debug.account.after.toFixed(4)} key total` +
+            (debug.account.limit != null
+              ? ` of $${debug.account.limit} limit`
+              : ''),
+        ]
+      : []),
+  ];
+
+  if (inconclusive) lines.push('', `*Why:* ${inconclusive}`);
+
+  // The reasons validation discarded findings are the most useful debugging
+  // signal there is: they mean the model found something and we threw it away.
+  const reasons = [...new Set(batches.flatMap(b => b.rejected ?? []))].slice(
+    0,
+    5
+  );
+  if (reasons.length) {
+    lines.push('', '*Rejected:*', ...reasons.map(r => `• ${r}`));
+  }
+
+  const errors = batches.filter(b => b.error).map(b => b.error.slice(0, 200));
+  if (errors.length)
+    lines.push('', '*Errors:*', ...errors.map(e => `• \`${e}\``));
+
+  // Per-batch request and response previews. The user message carries the
+  // rulebook digest and the diff; its head shows which files went out. Slack
+  // rejects payloads past ~40k characters, so previews shrink to fit.
+  for (const b of batches) {
+    const req = b.request?.messages?.at(-1)?.content;
+    const resp = b.response ?? b.unparseable;
+    if (!req && !resp) continue;
+    lines.push('', `*— Batch ${b.batch}* (\`${b.model || 'failed'}\`)`);
+    if (req)
+      lines.push(
+        `*Sent* (${req.length} chars):`,
+        '```' + clip(req, 700) + '```'
+      );
+    if (resp)
+      lines.push(
+        `*Received* (${resp.length} chars):`,
+        '```' + clip(resp, 1200) + '```'
+      );
+  }
+
+  lines.push('', `<${runUrl}|Run log and artifact>`);
+
+  // Hard ceiling: drop preview lines from the end until the payload fits,
+  // keeping the summary and the run link.
+  while (lines.join('\n').length > 38000 && lines.length > 12) {
+    lines.splice(lines.length - 3, 1);
+  }
+
+  try {
+    const res = await fetch(WEBHOOK, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: lines.join('\n'), mrkdwn: true }),
+    });
+    console.log(
+      res.ok
+        ? 'Posted the review digest to Slack.'
+        : `Slack rejected the digest: ${res.status} ${(await res.text()).slice(0, 200)}`
+    );
+  } catch (err) {
+    console.error(`Could not reach Slack: ${scrub(err.message)}`);
+  }
+}
+
+main().catch(err => {
+  console.error(`notify-slack failed: ${scrub(err.message)}`);
+});

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -103,14 +103,12 @@ function commentBody(f) {
     f.body,
   ];
 
-  if (f.suggestion) {
-    parts.push(
-      '',
-      '```suggestion',
-      f.suggestion.replace(/^```\w*\n?|```$/g, ''),
-      '```'
-    );
-  }
+  /*
+   * No ```suggestion fences. The model kept writing prose advice into them,
+   * and GitHub's "Apply suggestion" button commits fence content into the file
+   * verbatim — one click would have replaced a line of code with a sentence.
+   * Suggestions were also most of the paid output tokens.
+   */
 
   parts.push(
     '',
@@ -439,9 +437,9 @@ function applyMergeGate(blocking, incomplete) {
 
 main().catch(err => {
   // An API failure before the gate ran means we do not know whether this PR is
-  // clean. Exiting zero here would publish a green check on an unread review.
-  failIncomplete(`post-review failed before the gate ran (${err.message})`);
-  // Log loudly, exit clean. The reviewer is advisory; it must never be the
-  // reason a pull request cannot merge.
+  // clean. Exiting zero here would publish a green check on an unread review,
+  // so failIncomplete sets the exit code (when REQUIRE_COMPLETE_REVIEW is on)
+  // and returns — it never exits, the log below always runs.
   console.error(`post-review failed: ${err.stack || err.message}`);
+  failIncomplete(`post-review failed before the gate ran (${err.message})`);
 });

--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -117,6 +117,69 @@ Reply with exactly this JSON shape:
 If you find nothing worth reporting, return an empty findings array. That is a perfectly good answer.`;
 }
 
+/*
+ * The shape we force the model into via `response_format: json_schema`.
+ *
+ * This is deliberately a separate, looser object from findings.schema.json.
+ * Strict mode requires every property to appear in `required` and forbids
+ * additionalProperties, so genuinely optional fields (endLine, suggestion)
+ * have to be declared nullable rather than omitted. findings.schema.json stays
+ * the stricter contract that post-review.mjs validates the written file
+ * against; this one only has to survive the provider's validator.
+ */
+const RESPONSE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'findings'],
+  properties: {
+    summary: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'ruleId',
+          'file',
+          'line',
+          'endLine',
+          'severity',
+          'confidence',
+          'title',
+          'body',
+          'suggestion',
+        ],
+        properties: {
+          ruleId: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          endLine: { type: ['integer', 'null'] },
+          severity: {
+            type: 'string',
+            enum: ['blocker', 'major', 'minor', 'nit'],
+          },
+          confidence: { type: 'number' },
+          title: { type: 'string' },
+          body: { type: 'string' },
+          suggestion: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+};
+
+/*
+ * Not every model in the chain supports structured outputs, and the ones that
+ * do not are free to invent key names. Accept the spellings they actually
+ * reach for so a good finding is not discarded over casing.
+ */
+function pick(obj, ...names) {
+  for (const n of names) {
+    if (obj[n] !== undefined && obj[n] !== null) return obj[n];
+  }
+  return undefined;
+}
+
 /** Keep only findings that name a file we actually sent and a rule that exists. */
 function sanitise(findings, chunkFiles, validRuleIds) {
   const fileSet = new Set(chunkFiles);
@@ -126,22 +189,33 @@ function sanitise(findings, chunkFiles, validRuleIds) {
   for (const f of Array.isArray(findings) ? findings : []) {
     if (!f || typeof f !== 'object') continue;
 
-    const ruleId = String(f.ruleId || '')
+    const rawRuleId = pick(f, 'ruleId', 'rule_id', 'ruleID', 'rule', 'id');
+    const file = pick(f, 'file', 'path', 'filename', 'file_path');
+    const ruleId = String(rawRuleId || '')
       .toUpperCase()
       .trim();
-    const line = Number.parseInt(f.line, 10);
-    const endLine = Number.parseInt(f.endLine, 10);
-    const severity = String(f.severity || '')
+    const line = Number.parseInt(
+      pick(f, 'line', 'line_number', 'lineNumber'),
+      10
+    );
+    const endLine = Number.parseInt(pick(f, 'endLine', 'end_line'), 10);
+    const severity = String(pick(f, 'severity', 'level') || '')
       .toLowerCase()
       .trim();
-    const confidence = Number(f.confidence);
+    const confidence = Number(pick(f, 'confidence', 'score'));
 
-    if (!validRuleIds.has(ruleId)) {
-      rejected.push(`invented rule id ${f.ruleId}`);
+    if (!ruleId) {
+      rejected.push(
+        `missing rule id (model returned keys: ${Object.keys(f).join(', ') || 'none'})`
+      );
       continue;
     }
-    if (!fileSet.has(f.file)) {
-      rejected.push(`file not in this batch: ${f.file}`);
+    if (!validRuleIds.has(ruleId)) {
+      rejected.push(`invented rule id ${ruleId}`);
+      continue;
+    }
+    if (!fileSet.has(file)) {
+      rejected.push(`file not in this batch: ${file}`);
       continue;
     }
     if (!Number.isInteger(line) || line < 1) {
@@ -156,20 +230,22 @@ function sanitise(findings, chunkFiles, validRuleIds) {
       rejected.push(`confidence below threshold on ${ruleId}`);
       continue;
     }
-    if (!f.title || !f.body) {
+    const title = pick(f, 'title', 'summary', 'message');
+    const body = pick(f, 'body', 'description', 'detail', 'explanation');
+    if (!title || !body) {
       rejected.push(`missing title or body on ${ruleId}`);
       continue;
     }
 
     out.push({
       ruleId,
-      file: f.file,
+      file,
       line,
       ...(Number.isInteger(endLine) && endLine >= line ? { endLine } : {}),
       severity,
       confidence: Math.min(1, Math.max(0, confidence)),
-      title: String(f.title).slice(0, 120),
-      body: String(f.body).slice(0, 4000),
+      title: String(title).slice(0, 120),
+      body: String(body).slice(0, 4000),
       ...(f.suggestion
         ? { suggestion: String(f.suggestion).slice(0, 2000) }
         : {}),
@@ -322,6 +398,7 @@ async function main() {
         }),
         maxTokens: MAX_OUTPUT_TOKENS,
         jsonMode,
+        schema: RESPONSE_SCHEMA,
         title: `PR Review #${PR_NUMBER}`,
       });
     } catch (err) {

--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -87,6 +87,8 @@ ${files}
 DIFF
 ${diff}
 
+Rules apply only to files under src/ — the application. Do not report findings on other paths (.github/, config files, CI scripts); they are tooling, not the app. The exceptions are SEC and PHI rules, which apply everywhere: a committed credential or a leaked patient identifier is a defect wherever it sits.
+
 Report only problems in lines this diff ADDS or MODIFIES. Lines starting with "+" are added; lines starting with " " are unchanged context shown for reference only — do not report issues in them.
 
 You are seeing only the diff, not the whole repository. If judging something would require code you cannot see, either lower your confidence accordingly or leave it out.
@@ -104,8 +106,7 @@ Reply with exactly this JSON shape:
       "severity": "blocker | major | minor | nit",
       "confidence": 0.85,
       "title": "one line, under 80 characters",
-      "body": "why this is a problem here and what to do about it",
-      "suggestion": "optional: exact replacement code for those lines, no code fences"
+      "body": "ONE sentence: why it is a problem and what to do. Two only when one truly cannot carry it."
     }
   ]
 }
@@ -147,7 +148,6 @@ const RESPONSE_SCHEMA = {
           'confidence',
           'title',
           'body',
-          'suggestion',
         ],
         properties: {
           ruleId: { type: 'string' },
@@ -161,7 +161,6 @@ const RESPONSE_SCHEMA = {
           confidence: { type: 'number' },
           title: { type: 'string' },
           body: { type: 'string' },
-          suggestion: { type: ['string', 'null'] },
         },
       },
     },
@@ -178,6 +177,17 @@ function pick(obj, ...names) {
     if (obj[n] !== undefined && obj[n] !== null) return obj[n];
   }
   return undefined;
+}
+
+/*
+ * The rulebook's scope, enforced in code. The Scope section says rules apply
+ * to src/** and not to tooling — but prose in a prompt is advisory, and the
+ * model demonstrably reports STD findings on .github/** anyway. SEC and PHI
+ * are the exception: a committed credential is a defect wherever it appears.
+ */
+function inScope(file, ruleId) {
+  if (ruleId.startsWith('SEC-') || ruleId.startsWith('PHI-')) return true;
+  return file.startsWith('src/');
 }
 
 /** Keep only findings that name a file we actually sent and a rule that exists. */
@@ -218,6 +228,10 @@ function sanitise(findings, chunkFiles, validRuleIds) {
       rejected.push(`file not in this batch: ${file}`);
       continue;
     }
+    if (!inScope(file, ruleId)) {
+      rejected.push(`out of scope for ${ruleId}: ${file}`);
+      continue;
+    }
     if (!Number.isInteger(line) || line < 1) {
       rejected.push(`bad line on ${ruleId}`);
       continue;
@@ -245,10 +259,7 @@ function sanitise(findings, chunkFiles, validRuleIds) {
       severity,
       confidence: Math.min(1, Math.max(0, confidence)),
       title: String(title).slice(0, 120),
-      body: String(body).slice(0, 4000),
-      ...(f.suggestion
-        ? { suggestion: String(f.suggestion).slice(0, 2000) }
-        : {}),
+      body: String(body).slice(0, 600),
     });
   }
   return { findings: out, rejected };
@@ -403,7 +414,12 @@ async function main() {
       });
     } catch (err) {
       console.error(`Batch ${i + 1} failed: ${err.message}`);
-      debug.push({ batch: i + 1, files: chunkFiles, error: err.message });
+      debug.push({
+        batch: i + 1,
+        files: chunkFiles,
+        error: err.message,
+        request: err.request ?? null,
+      });
       failures++;
       continue;
     }
@@ -442,6 +458,8 @@ async function main() {
         files: chunkFiles,
         model: result.model,
         unparseable: result.text.slice(0, 1200),
+        request: result.request,
+        response: result.text,
       });
       failures++;
       continue;
@@ -477,6 +495,8 @@ async function main() {
       usage: result.usage,
       kept: findings.length,
       rejected,
+      request: result.request,
+      response: result.text,
     });
   }
 
@@ -538,9 +558,30 @@ async function main() {
     reviewed: !inconclusive,
     ...(inconclusive ? { inconclusive } : {}),
   });
+  /*
+   * The run's real bill, from the account itself: key usage after minus key
+   * usage before. Catches whatever per-request numbers miss (repair calls,
+   * retries billed without a usage block). May read a little low if
+   * OpenRouter's accounting has not settled by the time this runs.
+   */
+  const statusAfter = await keyStatus(API_KEY);
+  const account =
+    status && statusAfter
+      ? {
+          before: status.usage ?? null,
+          after: statusAfter.usage ?? null,
+          billed:
+            typeof statusAfter.usage === 'number' &&
+            typeof status.usage === 'number'
+              ? Number((statusAfter.usage - status.usage).toFixed(6))
+              : null,
+          limit: statusAfter.limit ?? null,
+        }
+      : null;
+
   writeFileSync(
     DEBUG_PATH,
-    JSON.stringify({ chain: chain.map(m => m.id), debug }, null, 2)
+    JSON.stringify({ chain: chain.map(m => m.id), account, debug }, null, 2)
   );
   console.log(`Wrote ${all.length} finding(s) to ${FINDINGS_PATH}.`);
 }

--- a/.github/review/scripts/test/gate.test.mjs
+++ b/.github/review/scripts/test/gate.test.mjs
@@ -88,3 +88,72 @@ test('finding ids are stable across runs but distinguish real differences', () =
   assert.notEqual(findingId(f()), findingId(f({ line: 11 })));
   assert.notEqual(findingId(f()), findingId(f({ ruleId: 'SEC-002' })));
 });
+
+test('the same rule on the same file is capped at two comments', () => {
+  // A live run posted six near-identical GEN-000 comments on one file.
+  const findings = Array.from({ length: 6 }, (_, i) => ({
+    ruleId: 'GEN-000',
+    file: 'src/review.mjs',
+    line: 100 + i,
+    severity: 'minor',
+    confidence: 0.8,
+    title: `t${i}`,
+    body: 'b',
+  }));
+  const { kept, dropped } = gateFindings(findings);
+  assert.equal(kept.length, 2);
+  assert.equal(dropped.length, 4);
+  assert.match(dropped[0].reason, /GEN-000 on src\/review\.mjs/);
+});
+
+test('the per-rule-file cap does not starve other files or rules', () => {
+  const findings = [
+    {
+      ruleId: 'GEN-000',
+      file: 'src/a.ts',
+      line: 1,
+      severity: 'minor',
+      confidence: 0.8,
+      title: 't',
+      body: 'b',
+    },
+    {
+      ruleId: 'GEN-000',
+      file: 'src/a.ts',
+      line: 2,
+      severity: 'minor',
+      confidence: 0.8,
+      title: 't',
+      body: 'b',
+    },
+    {
+      ruleId: 'GEN-000',
+      file: 'src/a.ts',
+      line: 3,
+      severity: 'minor',
+      confidence: 0.8,
+      title: 't',
+      body: 'b',
+    },
+    {
+      ruleId: 'GEN-000',
+      file: 'src/b.ts',
+      line: 1,
+      severity: 'minor',
+      confidence: 0.8,
+      title: 't',
+      body: 'b',
+    },
+    {
+      ruleId: 'STD-008',
+      file: 'src/a.ts',
+      line: 9,
+      severity: 'major',
+      confidence: 0.8,
+      title: 't',
+      body: 'b',
+    },
+  ];
+  const { kept } = gateFindings(findings);
+  assert.equal(kept.length, 4);
+});

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -259,6 +259,7 @@ test('ranking does not mutate the caller array', () => {
 async function startStub({ replies, models = AVAILABLE }) {
   const calls = [];
   let i = 0;
+  let keyReads = 0;
   const server = createServer((req, res) => {
     let body = '';
     req.on('data', c => (body += c));
@@ -276,8 +277,11 @@ async function startStub({ replies, models = AVAILABLE }) {
           })),
         });
       }
+      // Usage grows on each read so the billed-delta calculation is testable.
       if (req.url.endsWith('/key'))
-        return send(200, { data: { usage: 1, limit: null } });
+        return send(200, {
+          data: { usage: 1 + keyReads++ * 0.005, limit: null },
+        });
       if (req.url.endsWith('/chat/completions')) {
         calls.push(JSON.parse(body));
         const reply = replies[Math.min(i++, replies.length - 1)];
@@ -336,8 +340,13 @@ async function runReview(stub, { diff = DIFF, rules, env = {} } = {}) {
   const findings = JSON.parse(
     await readFile(join(dir, '.claude-review', 'findings.json'), 'utf8')
   );
+  // Early exits (no API key) legitimately write findings without a debug file.
+  const debug = await readFile(
+    join(dir, '.claude-review', 'openrouter-debug.json'),
+    'utf8'
+  ).then(JSON.parse, () => null);
   await rm(dir, { recursive: true, force: true });
-  return { stdout, stderr, findings };
+  return { stdout, stderr, findings, debug };
 }
 
 const RULES_FILE = `# Rulebook
@@ -632,6 +641,131 @@ test('a finding keyed rule_id survives instead of being thrown away', async () =
     assert.equal(findings.findings.length, 1);
     assert.equal(findings.findings[0].ruleId, 'SEC-001');
     assert.equal(findings.findings[0].file, 'src/a.ts');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('findings outside src/ are rejected unless the rule is SEC or PHI', async () => {
+  // The rulebook scopes rules to src/**, but prose in a prompt is advisory —
+  // a live run reported STD findings on .github/** anyway. Enforced in code.
+  const ciDiff = `diff --git a/.github/scripts/deploy.mjs b/.github/scripts/deploy.mjs
+index 111..222 100644
+--- a/.github/scripts/deploy.mjs
++++ b/.github/scripts/deploy.mjs
+@@ -1,2 +1,4 @@
+ const x = 1;
++console.log(x);
++const token = 'hardcoded';
+`;
+  const reply = JSON.stringify({
+    summary: 'x',
+    findings: [
+      {
+        ruleId: 'STD-008',
+        file: '.github/scripts/deploy.mjs',
+        line: 2,
+        severity: 'major',
+        confidence: 0.9,
+        title: 'console in tooling — out of scope',
+        body: 'b',
+      },
+      {
+        ruleId: 'SEC-001',
+        file: '.github/scripts/deploy.mjs',
+        line: 3,
+        severity: 'blocker',
+        confidence: 0.9,
+        title: 'a credential is in scope anywhere',
+        body: 'b',
+      },
+    ],
+  });
+  const stub = await startStub({ replies: [{ content: reply }] });
+  try {
+    const { findings } = await runReview(stub, {
+      diff: ciDiff,
+      rules: RULES_FILE,
+    });
+    assert.equal(findings.findings.length, 1);
+    assert.equal(findings.findings[0].ruleId, 'SEC-001');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the model is no longer asked for suggestion blocks', async () => {
+  // Models filled ```suggestion fences with prose; applying one would commit
+  // a sentence into source. Dropped — also most of the paid output tokens.
+  const stub = await startStub({
+    replies: [{ content: OBJ }],
+    models: LIVE_CHAIN,
+  });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    const [call] = stub.calls;
+    const props =
+      call.response_format.json_schema.schema.properties.findings.items;
+    assert.ok(!('suggestion' in props.properties));
+    assert.ok(!props.required.includes('suggestion'));
+    assert.match(call.messages.at(-1).content, /ONE sentence/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('requests route to the cheapest provider', async () => {
+  // Two identical runs billed ~70% apart per token — same model id, different
+  // provider behind it. Input is ~99% of this workload's tokens.
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    for (const call of stub.calls)
+      assert.deepEqual(call.provider, { sort: 'price' });
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the debug artifact holds the full request and response per batch', async () => {
+  // The Slack digest shows truncated previews; the artifact is the full
+  // fidelity copy. Without it, debugging a bad reply means re-running the PR.
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    const { debug } = await runReview(stub, { rules: RULES_FILE });
+    const [batch] = debug.debug;
+    assert.ok(batch.request.messages.length >= 2);
+    assert.match(batch.request.messages.at(-1).content, /DIFF/);
+    assert.equal(batch.response, OBJ);
+    assert.ok(
+      !JSON.stringify(batch.request).includes('stub-key'),
+      'the API key must never reach the artifact'
+    );
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the debug artifact records what the key was actually billed', async () => {
+  // Per-request cost sums miss repair calls and unsettled accounting. The
+  // key's usage delta, straight from OpenRouter, is the source of truth.
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    const { debug } = await runReview(stub, { rules: RULES_FILE });
+    assert.ok(debug.account);
+    assert.equal(debug.account.billed, 0.005);
+    assert.equal(debug.account.after, 1.005);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('every request asks OpenRouter to include its accounting', async () => {
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    for (const call of stub.calls)
+      assert.deepEqual(call.usage, { include: true });
   } finally {
     stub.server.close();
   }

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -187,6 +187,13 @@ test('returns null rather than guessing on unusable output', () => {
 
 // --- model selection -------------------------------------------------------
 
+/* The chain configured in production, so the tests exercise what actually runs. */
+const LIVE_CHAIN = [
+  { id: 'deepseek/deepseek-v4-pro', context: 204800, structured: true },
+  { id: 'qwen/qwen3-coder', context: 262144, structured: true },
+  { id: 'z-ai/glm-4.7', context: 204800, structured: true },
+];
+
 const AVAILABLE = [
   { id: 'big/model:free', context: 262144, structured: false },
   { id: 'mid/model:free', context: 128000, structured: true },
@@ -537,9 +544,11 @@ test('JSON mode is only requested when every model in the chain supports it', as
   });
   try {
     await runReview(allStructured, { rules: RULES_FILE });
-    assert.deepEqual(allStructured.calls[0].response_format, {
-      type: 'json_object',
-    });
+    assert.equal(
+      allStructured.calls[0].response_format.type,
+      'json_schema',
+      'a fully structured chain gets the strict schema, not bare json_object'
+    );
   } finally {
     allStructured.server.close();
   }
@@ -565,4 +574,65 @@ test('structured output still outranks non-reasoning', () => {
     'thinker:v1',
     'JSON support is the harder constraint'
   );
+});
+
+test('pins the reply shape with a strict json_schema, not bare json_object', async () => {
+  // Regression: `json_object` only guarantees valid JSON, not field names. A
+  // model replied with `rule_id` instead of `ruleId` and all five findings were
+  // discarded as "invented rule id undefined".
+  const stub = await startStub({
+    replies: [{ content: OBJ }],
+    models: LIVE_CHAIN,
+  });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    const [call] = stub.calls;
+    assert.equal(call.response_format.type, 'json_schema');
+    assert.equal(call.response_format.json_schema.strict, true);
+    const props = call.response_format.json_schema.schema.properties;
+    assert.ok(props.findings.items.required.includes('ruleId'));
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('every request asks the provider not to reason', async () => {
+  // deepseek-v4-pro spent 4000 of 4001 completion tokens reasoning and returned
+  // the single line "No diff was provided for review." — the diff had been sent
+  // (prompt_tokens 1978), the reply was simply truncated away.
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    assert.ok(stub.calls.length > 0);
+    for (const call of stub.calls)
+      assert.deepEqual(call.reasoning, { enabled: false });
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a finding keyed rule_id survives instead of being thrown away', async () => {
+  const snake = JSON.stringify({
+    summary: 'x',
+    findings: [
+      {
+        rule_id: 'SEC-001',
+        path: 'src/a.ts',
+        line_number: 2,
+        level: 'major',
+        score: 0.9,
+        message: 'hardcoded secret',
+        description: 'move it to an env var',
+      },
+    ],
+  });
+  const stub = await startStub({ replies: [{ content: snake }] });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1);
+    assert.equal(findings.findings[0].ruleId, 'SEC-001');
+    assert.equal(findings.findings[0].file, 'src/a.ts');
+  } finally {
+    stub.server.close();
+  }
 });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -173,6 +173,19 @@ jobs:
           BLOCK_MIN_SEVERITY: 'nit'
         run: node .github/review/scripts/post-review.mjs
 
+      - name: Slack review digest
+        # Opt-in debugging. REVIEW_SLACK_DEBUG is a repo variable; the webhook
+        # is a secret, because a Slack webhook URL is a bearer credential —
+        # anyone holding it can post to the channel.
+        if: always() && steps.pr.outputs.mode == 'review' && vars.REVIEW_SLACK_DEBUG == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RUN_ID: ${{ github.run_id }}
+        run: node .github/review/scripts/notify-slack.mjs
+
       - name: Clear the review-again label
         # Removed so it can be applied again. A label that stays put can only
         # trigger once, which is a confusing way for an on-demand switch to fail.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -143,13 +143,13 @@ jobs:
           # attacker-controlled text and must never reach a `run:` block inline.
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          MAX_REQUESTS: '4'
-          # Reasoning models spend this budget thinking before they answer, and
-          # what is left is the reply. At 4000 a reasoning model can burn the
-          # lot on reasoning and return a truncated fragment — observed on
-          # deepseek-v4-pro: 4000 of 4001 completion tokens were reasoning, and
-          # the reply was the single line "No diff was provided for review."
-          MAX_OUTPUT_TOKENS: '16000'
+          # ~3% of this repo's merged PRs exceed 4 requests (measured across 40:
+          # median 28KB / 1 batch, but #297 needed 5 and #301 exactly 4). Files
+          # beyond the cap are dropped and the review reports inconclusive.
+          MAX_REQUESTS: '6'
+          # Reasoning is switched off at the request (see lib/openrouter.mjs),
+          # so this budget is the reply alone.
+          MAX_OUTPUT_TOKENS: '8000'
         run: node .github/review/scripts/review.mjs
 
       - name: Post review


### PR DESCRIPTION
The full implementation validated on the testbed (testbed PR #19), ported here unchanged. Two commits.

## 1. Fix the two faults from the #303 live run

**Findings were parsed, then thrown away.** Requests sent `response_format: { type: 'json_object' }`, which guarantees valid JSON but not key names. The model replied `rule_id` instead of `ruleId`, so every finding failed the known-rule check and the log printed `invented rule id undefined`. Now `response_format: { type: 'json_schema', strict: true }` pins the shape, key-alias normalisation in `sanitise()` covers chain members that ignore the schema, and rejection messages name the keys the model actually returned.

**Reasoning burned the budget.** `deepseek-v4-pro` spent 4000 of 4001 completion tokens thinking and replied "No diff was provided for review." Every request now sends `reasoning: { enabled: false }` — reviewing a diff against a fixed rulebook is pattern-matching, not deduction. `MAX_OUTPUT_TOKENS` drops 16000 → 8000 (the bump only compensated for reasoning), `MAX_REQUESTS` rises 4 → 6 (~3% of merged PRs here were being silently truncated into inconclusive).

## 2. Scope, noise, cost, and observability — each change traced to a defect observed live

- **Rule scope enforced in code.** The rulebook scopes rules to `src/**`, but prose is advisory — a live run reported STD findings on `.github/**` with the exception clause quoted backwards. `sanitise()` now rejects findings outside `src/**` unless the rule is `SEC`/`PHI`. Validated in both directions in one run: ASYNC on tooling rejected, SEC blocker on the same file kept.
- **Suggestion blocks removed.** Models wrote prose into ```suggestion fences; GitHub's "Apply suggestion" commits fence content into source verbatim. Also most of the paid output tokens.
- **Terse findings.** One-sentence bodies enforced in the prompt, 600-char cap in code, repeats of one rule on one file capped at 2 (a run posted six near-identical comments on one file). Output tokens measured −92%.
- **Cheapest-provider routing.** Two identical runs billed ~70% apart per token — same model id, different provider. Input is ~99% of this workload's tokens, so `provider: { sort: 'price' }` on every request.
- **Slack digest** (opt-in: `REVIEW_SLACK_DEBUG` variable + `SLACK_WEBHOOK_URL` secret). Per-run: PR author, chain, served-by, batches, findings kept/rejected with reasons, tokens, per-request cost, and the key's **real billed delta** from OpenRouter's `/key` endpoint read before and after the run. Includes truncated per-batch payload/response previews — full copies live in the run artifact (`openrouter-debug.json`), where a test asserts the API key can never appear. The webhook URL is scrubbed from anything the script logs — a fix for a SEC-003 blocker the agent itself raised against this code on the testbed.

## Verification

75 tests pass; fixtures mirror the production chain. Every change validated by live runs on the testbed PR, including one where the agent reviewed this very implementation, rejected its own out-of-scope finding, and raised a real credential-handling blocker that is fixed here.

## Setup to light up Slack here

`REVIEW_SLACK_DEBUG=true` variable + `SLACK_WEBHOOK_URL` secret. Recommended alongside: put `qwen/qwen3-coder` first in `OPENROUTER_MODELS` (non-reasoning, cheapest of the three on output).