### PR TITLE
Strip PR template boilerplate from the prompt and land the Slack preview on the diff

### DIFF
--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -286,6 +286,7 @@ export async function complete(opts) {
     ],
     temperature: 0.1,
     max_tokens: maxTokens,
+    frequency_penalty: 0.4,
     // Ask for OpenRouter's own accounting in every reply, rather than relying
     // on the provider including it by default.
     usage: { include: true },

--- a/.github/review/scripts/notify-slack.mjs
+++ b/.github/review/scripts/notify-slack.mjs
@@ -132,15 +132,36 @@ async function main() {
   // Per-batch request and response previews. The user message carries the
   // rulebook digest and the diff; its head shows which files went out. Slack
   // rejects payloads past ~40k characters, so previews shrink to fit.
+  /*
+   * The payload is title → description → rules → files → DIFF, so a plain
+   * head-truncation shows boilerplate and cuts off before any code. Show the
+   * head briefly, elide the rules digest, and land on the diff itself.
+   */
+  const previewOf = req => {
+    const diffAt = req.indexOf('\nDIFF\n');
+    if (diffAt === -1) return clip(req, 700);
+    const diff = req.slice(diffAt + 6);
+    return (
+      clip(req.slice(0, Math.min(diffAt, 300)), 300) +
+      `\n⋯ rules digest elided ⋯\nDIFF (${diff.length} chars):\n` +
+      clip(diff, 900)
+    );
+  };
+
   for (const b of batches) {
     const req = b.request?.messages?.at(-1)?.content;
     const resp = b.response ?? b.unparseable;
     if (!req && !resp) continue;
     lines.push('', `*— Batch ${b.batch}* (\`${b.model || 'failed'}\`)`);
+    if (b.files?.length)
+      lines.push(
+        `*Files:* ${b.files.slice(0, 6).join(', ')}` +
+          (b.files.length > 6 ? ` +${b.files.length - 6} more` : '')
+      );
     if (req)
       lines.push(
         `*Sent* (${req.length} chars):`,
-        '```' + clip(req, 700) + '```'
+        '```' + previewOf(req) + '```'
       );
     if (resp)
       lines.push(

--- a/.github/review/scripts/notify-slack.mjs
+++ b/.github/review/scripts/notify-slack.mjs
@@ -70,8 +70,11 @@ async function main() {
   const rejected = batches.reduce((n, b) => n + (b.rejected?.length || 0), 0);
   const served = [...new Set(batches.map(b => b.model).filter(Boolean))];
 
-  const inconclusive =
-    findings?.reviewed === false ? findings.inconclusive : null;
+  const inconclusive = findings
+    ? findings.reviewed === false
+      ? findings.inconclusive
+      : null
+    : 'no findings.json was produced — the job likely failed before review.mjs ran';
   const status = inconclusive
     ? '🔴 inconclusive'
     : kept > 0

--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -43,7 +43,21 @@ const DEBUG_PATH = join(OUT_DIR, 'openrouter-debug.json');
 const API_KEY = process.env.OPENROUTER_API_KEY;
 const PR_NUMBER = process.env.PR_NUMBER || '0';
 const PR_TITLE = process.env.PR_TITLE || '';
-const PR_BODY = (process.env.PR_BODY || '').slice(0, 1500);
+
+/*
+ * The description is repeated in every batch, so template boilerplate is paid
+ * for N times over. Unfilled PR templates are mostly HTML comments and
+ * unchecked boxes — strip both before the length cap, so the cap spends its
+ * budget on whatever the author actually wrote.
+ */
+function cleanPrBody(body) {
+  return body
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/^\s*-\s*\[\s?\]\s.*$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+const PR_BODY = cleanPrBody(process.env.PR_BODY || '').slice(0, 1500);
 const MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 4;
 const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 4000;
 const PREFERRED = (process.env.OPENROUTER_MODELS || '')

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -770,3 +770,30 @@ test('every request asks OpenRouter to include its accounting', async () => {
     stub.server.close();
   }
 });
+
+test('PR template boilerplate never reaches the model', async () => {
+  // The description rides along in every batch. An unfilled template is HTML
+  // comments and unchecked boxes — N batches of paid tokens saying nothing.
+  const template = [
+    '# Pull Request',
+    '<!-- Provide a brief description of the changes in this PR -->',
+    'fixes the visit export off-by-one',
+    '- [ ] Bug fix (non-breaking change which fixes an issue)',
+    '- [ ] New feature (non-breaking change which adds functionality)',
+    '- [x] Test updates',
+  ].join('\n');
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    await runReview(stub, {
+      rules: RULES_FILE,
+      env: { PR_BODY: template },
+    });
+    const sent = stub.calls[0].messages.at(-1).content;
+    assert.ok(!sent.includes('<!--'));
+    assert.ok(!sent.includes('- [ ]'));
+    assert.match(sent, /fixes the visit export off-by-one/);
+    assert.match(sent, /- \[x\] Test updates/);
+  } finally {
+    stub.server.close();
+  }
+});

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -528,6 +528,18 @@ test('the fallback chain is sent so OpenRouter can reroute on rate limits', asyn
   }
 });
 
+test('a frequency penalty is sent to discourage repetition loops', async () => {
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
+  });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    assert.ok(stub.calls[0].frequency_penalty > 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
 test('JSON mode is only requested when every model in the chain supports it', async () => {
   const mixed = await startStub({
     replies: [{ content: OBJ }],


### PR DESCRIPTION
Follow-up to #306, which merged just before this landed on its branch.

**The PR description is sent to the model on purpose** — it tells the reviewer the intent of the change, and it rides along in every batch. What was wasteful is that an unfilled PR template rode along too: yesterday's run on #307 sent the whole scaffold — HTML comments and eight unchecked checkboxes — five times over, saying nothing.

- `cleanPrBody()` strips `<!-- … -->` comments and unchecked `- [ ]` lines before the 1,500-char cap, so the cap's budget goes to what the author actually wrote. Checked boxes survive; they carry signal.
- The Slack digest's payload preview no longer truncates at the head (which showed the template and cut off before any code): it now shows the head briefly, elides the rules digest, and lands on the DIFF section, with a per-batch file list.

76 tests pass, including one asserting boilerplate never reaches the model while real sentences and checked boxes do. Validated on the testbed branch.
