### PR TITLE
Review agent: skip unit-test bodies, salvage truncated replies, drop the PR description

### DIFF
--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -44,6 +44,25 @@ export function splitDiffByFile(diff) {
 }
 
 /**
+ * Is this a unit-test file rather than application code?
+ *
+ * Test bodies are the bulk of a typical PR here and the least rewarding thing
+ * to spend input tokens on: a table-driven suite is hundreds of near-identical
+ * lines, which is also what sends a model into a repetition loop. Their names
+ * still travel with the prompt, so TEST-001/002 ("fix with no regression test")
+ * stay answerable without paying for the bodies.
+ *
+ * @param {string} path
+ */
+export function isTestFile(path) {
+  return (
+    /\.(test|spec)\.[cm]?[jt]sx?$/.test(path) ||
+    /(^|\/)__(tests|mocks)__\//.test(path) ||
+    /(^|\/)tests?\//.test(path)
+  );
+}
+
+/**
  * Pack per-file diffs into as few requests as possible without blowing the
  * context window.
  *
@@ -152,7 +171,57 @@ export function extractJson(text) {
       if (depth === 0) return attempt(s.slice(start, i + 1));
     }
   }
-  return null;
+  return salvageJson(s.slice(start));
+}
+
+/*
+ * Close a reply that ran out of output budget before it closed its brackets.
+ *
+ * Under `json_schema` the decoder is grammar-constrained, but JSON permits
+ * unlimited whitespace between tokens — so an emitted `{"findings": []` may be
+ * followed by thousands of newlines until max_tokens, legally, and the object
+ * never closes. Observed repeatedly on one file in PR #309: 8000 completion
+ * tokens, 255k chars, no `}`. A penalty only shifts the odds of a legal token;
+ * it cannot forbid it, which is why this must be recoverable rather than merely
+ * discouraged.
+ *
+ * The bytes the model did emit are its real answer. Drop the whitespace flood,
+ * shut any string and bracket still open, and parse what is left.
+ */
+export function salvageJson(text) {
+  const stack = [];
+  let out = '';
+  let inString = false;
+  let escaped = false;
+
+  for (const c of text) {
+    if (inString) {
+      out += c;
+      if (escaped) escaped = false;
+      else if (c === '\\') escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (/\s/.test(c)) continue;
+    out += c;
+    if (c === '"') inString = true;
+    else if (c === '{' || c === '[') stack.push(c === '{' ? '}' : ']');
+    else if (c === '}' || c === ']') stack.pop();
+  }
+
+  if (inString) out += '"';
+  // A dangling `,` or `:` is the start of a value that never arrived.
+  out = out.replace(/[,:]+$/, '');
+  while (stack.length) out += stack.pop();
+
+  try {
+    const parsed = JSON.parse(out);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -287,6 +356,13 @@ export async function complete(opts) {
     temperature: 0.1,
     max_tokens: maxTokens,
     frequency_penalty: 0.4,
+    /*
+     * Cut the whitespace runaway at the provider instead of paying for it to
+     * reach max_tokens. Pretty-printed JSON never contains a blank line, let
+     * alone four, so this cannot truncate a healthy reply — and salvageJson
+     * closes whatever the stop leaves open.
+     */
+    stop: ['\n\n\n\n'],
     // Ask for OpenRouter's own accounting in every reply, rather than relying
     // on the provider including it by default.
     usage: { include: true },

--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -24,6 +24,7 @@ import {
   complete,
   estimateTokens,
   extractJson,
+  isTestFile,
   keyStatus,
   listModels,
   MAX_FALLBACK_MODELS,
@@ -43,21 +44,6 @@ const DEBUG_PATH = join(OUT_DIR, 'openrouter-debug.json');
 const API_KEY = process.env.OPENROUTER_API_KEY;
 const PR_NUMBER = process.env.PR_NUMBER || '0';
 const PR_TITLE = process.env.PR_TITLE || '';
-
-/*
- * The description is repeated in every batch, so template boilerplate is paid
- * for N times over. Unfilled PR templates are mostly HTML comments and
- * unchecked boxes — strip both before the length cap, so the cap spends its
- * budget on whatever the author actually wrote.
- */
-function cleanPrBody(body) {
-  return body
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/^\s*-\s*\[\s?\]\s.*$/gm, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-const PR_BODY = cleanPrBody(process.env.PR_BODY || '').slice(0, 1500);
 const MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 4;
 const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 4000;
 const PREFERRED = (process.env.OPENROUTER_MODELS || '')
@@ -84,20 +70,27 @@ You are strict about false positives. A short review with two real problems is f
 
 Never report: formatting or style that a linter handles, naming preferences, missing comments, speculative refactors, praise, or restatements of what the code does.`;
 
-function userPrompt({ digest, chunk, chunkIndex, chunkCount }) {
+function userPrompt({ digest, chunk, chunkIndex, chunkCount, testFiles }) {
   const files = chunk.map(f => f.file).join('\n');
   const diff = chunk.map(f => f.patch).join('\n');
 
   return `Review this pull request diff against the rules below.
 
-${PR_TITLE ? `PULL REQUEST TITLE\n${PR_TITLE}\n` : ''}${PR_BODY ? `\nDESCRIPTION\n${PR_BODY}\n` : ''}
+${PR_TITLE ? `PULL REQUEST TITLE\n${PR_TITLE}\n` : ''}
 RULES — every finding must cite one of these rule IDs. If you find a real problem that no rule covers, use GEN-000 and name the missing rule in the body.
 
 ${digest}
 
 FILES IN THIS BATCH${chunkCount > 1 ? ` (batch ${chunkIndex + 1} of ${chunkCount})` : ''}
 ${files}
-
+${
+  testFiles.length
+    ? `
+TEST FILES THIS PR ALSO CHANGES — names only, bodies deliberately not sent. Treat these as tests that exist, so do not report a missing test for behaviour they cover, and do not report findings against these paths.
+${testFiles.join('\n')}
+`
+    : ''
+}
 DIFF
 ${diff}
 
@@ -385,7 +378,33 @@ async function main() {
     Math.floor(budgetTokens * CHARS_PER_TOKEN)
   );
 
-  const files = splitDiffByFile(diff);
+  const allFiles = splitDiffByFile(diff);
+  const files = allFiles.filter(f => !isTestFile(f.file));
+  const testFiles = allFiles.filter(f => isTestFile(f.file)).map(f => f.file);
+  if (testFiles.length) {
+    console.log(
+      `Skipping ${testFiles.length} unit-test file(s); names still sent so ` +
+        `"missing test" rules stay answerable.`
+    );
+  }
+
+  /*
+   * A tests-only PR has nothing left to review. That is a clean pass, not a
+   * failed one — reporting it inconclusive would wedge the merge behind a
+   * review that had no application code to look at.
+   */
+  if (files.length === 0) {
+    writeFindings({
+      summary: testFiles.length
+        ? `Only unit-test files changed (${testFiles.length}); no application code to review.`
+        : 'No reviewable changes in this pull request.',
+      findings: [],
+      reviewed: true,
+    });
+    console.log('No application code in this diff. Nothing to review.');
+    return;
+  }
+
   const { chunks, skipped, truncated } = packChunks(files, {
     budgetChars,
     maxChunks: MAX_REQUESTS,
@@ -420,6 +439,7 @@ async function main() {
           chunk,
           chunkIndex: i,
           chunkCount: chunks.length,
+          testFiles,
         }),
         maxTokens: MAX_OUTPUT_TOKENS,
         jsonMode,

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -20,6 +20,7 @@ import { dirname, join } from 'node:path';
 import {
   chooseModels,
   extractJson,
+  isTestFile,
   packChunks,
   rankModels,
   splitDiffByFile,
@@ -68,6 +69,34 @@ test('a renamed file is keyed by its new path', () => {
 test('an empty diff yields no sections', () => {
   assert.deepEqual(splitDiffByFile(''), []);
   assert.deepEqual(splitDiffByFile('   '), []);
+});
+
+// --- test-file detection ---------------------------------------------------
+
+test('recognises this repo’s unit-test paths', () => {
+  for (const p of [
+    'src/App.test.tsx',
+    'src/hooks/useColumnSort.test.ts',
+    'src/test/utils.tsx',
+    'src/test/mocks/react-datepicker.ts',
+    'src/test/modules/ayu/physical-examination.component.test.tsx',
+    'src/foo.spec.js',
+    'src/__tests__/thing.ts',
+    'src/__mocks__/thing.ts',
+  ]) {
+    assert.ok(isTestFile(p), `${p} should be treated as a test file`);
+  }
+});
+
+test('does not mistake application code for a test', () => {
+  for (const p of [
+    'src/modules/ayu-library/logic/visit-summary.logic.ts',
+    'src/features/latest/index.ts', // contains "test" but is not a test dir
+    'src/components/Contest.tsx',
+    'src/utils/testing-helpers-docs.md',
+  ]) {
+    assert.ok(!isTestFile(p), `${p} must stay reviewable`);
+  }
 });
 
 // --- chunk packing ---------------------------------------------------------
@@ -171,6 +200,17 @@ test('handles braces inside strings without losing the object', () => {
 test('handles escaped quotes inside strings', () => {
   const tricky = '{"summary":"he said \\"hi\\" then left","findings":[]}';
   assert.equal(extractJson(tricky).summary, 'he said "hi" then left');
+});
+
+test('a whitespace runaway is salvaged instead of discarded', () => {
+  // Grammar-constrained decoding still permits unlimited whitespace, so a
+  // reply can flood newlines to max_tokens and never close its object.
+  const flooded = '{\n  "findings": []\n' + '\n'.repeat(20000);
+  assert.deepEqual(extractJson(flooded), { findings: [] });
+
+  const midString =
+    '{"findings": [], "summary": "the export is off by' + '\n'.repeat(5000);
+  assert.equal(extractJson(midString).summary, 'the export is off by');
 });
 
 test('returns null rather than guessing on unusable output', () => {
@@ -528,13 +568,15 @@ test('the fallback chain is sent so OpenRouter can reroute on rate limits', asyn
   }
 });
 
-test('a frequency penalty is sent to discourage repetition loops', async () => {
+test('repetition loops are discouraged and cut off at the provider', async () => {
   const stub = await startStub({
     replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
   });
   try {
     await runReview(stub, { rules: RULES_FILE });
     assert.ok(stub.calls[0].frequency_penalty > 0);
+    // Without this the whitespace flood bills all the way to max_tokens.
+    assert.deepEqual(stub.calls[0].stop, ['\n\n\n\n']);
   } finally {
     stub.server.close();
   }
@@ -783,15 +825,47 @@ test('every request asks OpenRouter to include its accounting', async () => {
   }
 });
 
-test('PR template boilerplate never reaches the model', async () => {
-  // The description rides along in every batch. An unfilled template is HTML
-  // comments and unchecked boxes — N batches of paid tokens saying nothing.
+test('test bodies are withheld but their names are sent', async () => {
+  const mixed =
+    'diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1,2 @@\n+const y = 2;\n' +
+    'diff --git a/src/test/a.test.ts b/src/test/a.test.ts\n--- a/src/test/a.test.ts\n+++ b/src/test/a.test.ts\n@@ -1 +1,2 @@\n+expect(sekritTestBody).toBe(1);\n';
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    await runReview(stub, { diff: mixed, rules: RULES_FILE });
+    assert.equal(stub.calls.length, 1);
+    const sent = stub.calls[0].messages.at(-1).content;
+    assert.ok(!sent.includes('sekritTestBody'), 'the body must not be sent');
+    assert.match(sent, /src\/test\/a\.test\.ts/, 'the name must be sent');
+    assert.match(sent, /const y = 2/, 'application code still reviewed');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a tests-only PR passes cleanly instead of reporting inconclusive', async () => {
+  const testsOnly =
+    'diff --git a/src/test/a.test.ts b/src/test/a.test.ts\n--- a/src/test/a.test.ts\n+++ b/src/test/a.test.ts\n@@ -1 +1,2 @@\n+expect(1).toBe(1);\n';
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    const { findings } = await runReview(stub, {
+      diff: testsOnly,
+      rules: RULES_FILE,
+    });
+    assert.equal(stub.calls.length, 0, 'must not spend a request');
+    assert.equal(findings.reviewed, true, 'must not wedge the merge');
+    assert.equal(findings.inconclusive, undefined);
+    assert.match(findings.summary, /only unit-test files changed/i);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the PR description never reaches the model, template or not', async () => {
   const template = [
     '# Pull Request',
     '<!-- Provide a brief description of the changes in this PR -->',
     'fixes the visit export off-by-one',
     '- [ ] Bug fix (non-breaking change which fixes an issue)',
-    '- [ ] New feature (non-breaking change which adds functionality)',
     '- [x] Test updates',
   ].join('\n');
   const stub = await startStub({ replies: [{ content: OBJ }] });
@@ -801,10 +875,10 @@ test('PR template boilerplate never reaches the model', async () => {
       env: { PR_BODY: template },
     });
     const sent = stub.calls[0].messages.at(-1).content;
+    assert.ok(!sent.includes('DESCRIPTION'));
+    assert.ok(!sent.includes('fixes the visit export off-by-one'));
     assert.ok(!sent.includes('<!--'));
     assert.ok(!sent.includes('- [ ]'));
-    assert.match(sent, /fixes the visit export off-by-one/);
-    assert.match(sent, /- \[x\] Test updates/);
   } finally {
     stub.server.close();
   }

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -142,7 +142,6 @@ jobs:
           # Passed as env, not interpolated into a shell command — a PR title is
           # attacker-controlled text and must never reach a `run:` block inline.
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
           # ~3% of this repo's merged PRs exceed 4 requests (measured across 40:
           # median 28KB / 1 batch, but #297 needed 5 and #301 exactly 4). Files
           # beyond the cap are dropped and the review reports inconclusive.


### PR DESCRIPTION
## Description

Three fixes to the AI review agent, all found while debugging why #309 reported `inconclusive` on every run.

**1. Unit-test bodies are no longer sent.** Test files are the bulk of a typical PR here and the least rewarding use of input tokens — a table-driven suite is hundreds of near-identical lines, which is also exactly what sends a model into a repetition loop. Their **names** still travel with the prompt, so `TEST-001`/`TEST-002` ("fix with no regression test") stay answerable without paying for the bodies. A tests-only PR now passes cleanly rather than reporting inconclusive.

**2. Truncated JSON replies are salvaged.** Under `json_schema` the decoder is grammar-constrained, but JSON permits unlimited whitespace between tokens — so `{"findings": []` followed by thousands of newlines is *legal* output that never closes the object. Observed repeatedly on one file in #309: 8000 completion tokens, 255k chars, no `}`. `frequency_penalty` only shifts the odds of a legal token; it cannot forbid one, so this had to be recoverable rather than merely discouraged. `salvageJson()` drops the flood, closes what is still open, and parses what the model actually emitted. A `stop` sequence is also sent to cut the flood at the provider.

**3. The PR description is no longer sent at all.** It was only ever extra context — findings have always come from the diff. In practice it is an unfilled template on nearly every PR. (It also survived `cleanPrBody` looking mangled, because GitHub sends CRLF and the collapse regex only matched `\n` runs.)

## Measured on #309's real diff

| | Batches | Input tok | Output tok | Cost | Result |
|---|---|---|---|---|---|
| before | 3 | 28,209 | 8,130 | $0.0208 | 🔴 inconclusive, 0 findings |
| after | **1** | **6,871** | **317** | **$0.0024** | 🟢 **2 findings** |

~76% fewer input tokens, ~8.7x cheaper, and the first actual findings this PR has ever produced (a non-null assertion on a function that can return `undefined`, and a duplicated constant set).

## Known tradeoffs

- `TEST-003` (flaky test patterns) and `TEST-004` (assertions that cannot fail) can no longer fire — they need test bodies. 2 of 67 rules are now dead; worth deleting from the rulebook if we keep this.
- **SEC/PHI is no longer checked inside test files.** The rulebook deliberately scopes SEC/PHI to apply everywhere because a credential or patient identifier is a defect wherever it sits — real patient data in a test fixture is a classic PHI leak. Reviewing test files for SEC/PHI only (one extra small batch) would close this.

## Testing

- [x] `node --test .github/review/scripts/test/*.test.mjs` — 82/82 passing
- [x] Salvage verified against the real 255KB failed response from run 32452729362
- [x] Full #309 diff run end-to-end against the live API with the numbers above