### PR TITLE
Review agent: re-review on a different model when a reply cannot be parsed

### DIFF
--- a/.github/review/scripts/review.mjs
+++ b/.github/review/scripts/review.mjs
@@ -428,19 +428,21 @@ async function main() {
     const chunkFiles = chunk.map(f => f.file);
     if (i > 0) await sleep(REQUEST_SPACING_MS);
 
+    const prompt = userPrompt({
+      digest,
+      chunk,
+      chunkIndex: i,
+      chunkCount: chunks.length,
+      testFiles,
+    });
+
     let result;
     try {
       result = await complete({
         apiKey: API_KEY,
         models: chain.map(m => m.id),
         system: SYSTEM_PROMPT,
-        user: userPrompt({
-          digest,
-          chunk,
-          chunkIndex: i,
-          chunkCount: chunks.length,
-          testFiles,
-        }),
+        user: prompt,
         maxTokens: MAX_OUTPUT_TOKENS,
         jsonMode,
         schema: RESPONSE_SCHEMA,
@@ -460,29 +462,43 @@ async function main() {
 
     let parsed = extractJson(result.text);
 
-    // Free models sometimes narrate before the JSON. One cheap repair attempt.
+    /*
+     * A reply we cannot parse means this model failed on this input, so retry
+     * on a DIFFERENT one — the degeneracy is model- and input-specific, and
+     * asking the same model the same question tends to fail the same way.
+     *
+     * Send the original prompt, not the broken reply. The old repair pass fed
+     * the garbage back and asked for it as JSON, which produced a tidy summary
+     * of noise and an empty findings array — a batch that never reviewed the
+     * diff but no longer looked like a failure.
+     */
     if (!parsed) {
+      const others = chain.map(m => m.id).filter(id => id !== result.model);
       console.log(
-        `Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`
+        `Batch ${i + 1}: unparseable reply from ${result.model}; ` +
+          (others.length
+            ? `re-reviewing on ${others[0]}.`
+            : 'no other model in the chain to try.')
       );
       repaired++;
-      await sleep(REQUEST_SPACING_MS);
-      try {
-        const repair = await complete({
-          apiKey: API_KEY,
-          models: chain.map(m => m.id),
-          system: SYSTEM_PROMPT,
-          user:
-            'Your previous reply was not valid JSON. Return the same content as a single JSON ' +
-            'object with keys "summary" and "findings", and nothing else.\n\n' +
-            'Previous reply:\n' +
-            result.text.slice(0, 6000),
-          maxTokens: MAX_OUTPUT_TOKENS,
-          jsonMode,
-        });
-        parsed = extractJson(repair.text);
-      } catch (err) {
-        console.error(`Batch ${i + 1} repair failed: ${err.message}`);
+      if (others.length) {
+        await sleep(REQUEST_SPACING_MS);
+        try {
+          const retry = await complete({
+            apiKey: API_KEY,
+            models: others,
+            system: SYSTEM_PROMPT,
+            user: prompt,
+            maxTokens: MAX_OUTPUT_TOKENS,
+            jsonMode,
+            schema: RESPONSE_SCHEMA,
+            title: `PR Review #${PR_NUMBER}`,
+          });
+          parsed = extractJson(retry.text);
+          if (parsed) result = retry;
+        } catch (err) {
+          console.error(`Batch ${i + 1} retry failed: ${err.message}`);
+        }
       }
     }
 
@@ -578,9 +594,14 @@ async function main() {
     inconclusive = `${skipped.length} file(s) exceeded the ${MAX_REQUESTS}-request budget and were never read: ${skipped.join(', ')}`;
   } else if (all.length === 0 && GAVE_UP.test(summaries.join(' '))) {
     inconclusive = 'the model reported that it did not see the code';
-  } else if (all.length === 0 && repaired > 0) {
-    inconclusive = `${repaired} batch(es) returned unparseable output and then found nothing, which usually means the model did not engage with the diff`;
   }
+  /*
+   * An unparseable batch that never recovered is already counted in `failures`
+   * above. `repaired` only records that a retry was needed — and that retry now
+   * re-reviews the diff on a different model rather than reformatting the
+   * broken reply, so a recovered batch finding nothing is a real answer and
+   * must not be reported as a review that did not happen.
+   */
 
   if (inconclusive) {
     console.log(`Review is inconclusive: ${inconclusive}.`);

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -475,7 +475,7 @@ test('invented rule IDs and file paths are discarded', async () => {
   }
 });
 
-test('an unparseable reply triggers exactly one repair attempt', async () => {
+test('an unparseable reply is re-reviewed once on a different model', async () => {
   const stub = await startStub({
     replies: [
       { content: 'I am unable to produce JSON right now.' },
@@ -489,9 +489,39 @@ test('an unparseable reply triggers exactly one repair attempt', async () => {
   });
   try {
     const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
-    assert.match(stdout, /retrying once/);
+    assert.match(stdout, /re-reviewing on/);
     assert.equal(findings.findings.length, 1);
-    assert.equal(stub.calls.length, 2);
+    assert.equal(stub.calls.length, 2, 'exactly one retry');
+
+    // The model that failed must not lead the retry chain.
+    const served = 'big/model:free';
+    assert.ok(
+      !stub.calls[1].models.includes(served),
+      'the failed model must be dropped from the retry'
+    );
+    // The retry must re-review the diff, not reformat the broken reply.
+    const retryPrompt = stub.calls[1].messages.at(-1).content;
+    assert.match(retryPrompt, /const y = 2/, 'the diff must be re-sent');
+    assert.ok(
+      !retryPrompt.includes('I am unable to produce JSON'),
+      'the broken reply must not be fed back'
+    );
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a recovered batch that finds nothing is a real answer, not inconclusive', async () => {
+  const stub = await startStub({
+    replies: [
+      { content: 'no json here' },
+      { content: JSON.stringify({ summary: 'clean', findings: [] }) },
+    ],
+  });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.reviewed, true);
+    assert.equal(findings.inconclusive, undefined);
   } finally {
     stub.server.close();
   }


### PR DESCRIPTION
## Description

Follow-up to #312. Closes the last two paths by which an unparseable reply could still waste a batch.

**1. The retry used the same model.** `models: chain.map(m => m.id)` put `qwen/qwen3-coder` — the model that had just degenerated — first again. The degeneracy is model- and input-specific, so asking the same model the same question tends to fail the same way. The retry now drops the failed model and re-reviews on the next one in the chain.

**2. The retry did not re-review the diff.** It sent the *previous broken reply* back and asked for it as JSON. So even when it parsed, the result was a tidy summary of noise with an empty findings array — a batch that never looked at the code but no longer looked like a failure. That is exactly the "unparseable → then found nothing" pattern in the logs. The retry now re-sends the original prompt.

**3. Corrected the inconclusive rule.** `all.length === 0 && repaired > 0` was reported as "the model did not engage with the diff", which was true when the repair reformatted garbage. Now that a retry genuinely re-reviews on another model, a recovered batch finding nothing is a real answer. Batches that never recover are already counted in `failures`, which still reports inconclusive.

## Testing

- [x] `node --test .github/review/scripts/test/*.test.mjs` — 83/83 passing
- [x] New coverage asserts the failed model is dropped from the retry chain, that the diff is re-sent rather than the broken reply, and that a recovered empty batch is not reported inconclusive